### PR TITLE
Add .vscode/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 # rspec failure tracking
 .rspec_status
+.vscode/


### PR DESCRIPTION
I need to override some of my vscode settings (e.g. rubocop linting) to make sure I don't accidentally reformat project files, so the `.vscode/settings.json` being ignored by git would be nice :)