### PR TITLE
Add semicolon to generated rbi method definitions.

### DIFF
--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -108,7 +108,7 @@ module Sord
 
         rbi_contents << "  sig { params(#{sig_params_list}).#{returns} }"
 
-        rbi_contents << "  def #{prefix}#{meth.name}(#{parameter_list}) end"
+        rbi_contents << "  def #{prefix}#{meth.name}(#{parameter_list}); end"
       end
     end
 


### PR DESCRIPTION
This is the more common formatting from sorbet-typed, and I personally prefer it. If you're opposed to the change, feel free to close this.

```ruby
# Before
sig { params(param: String).void }
def method_name(param) end

# After
sig { params(param: String).void }
def method_name(param); end
```