### PR TITLE
Fix method generation for methods with keyword arguments

### DIFF
--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -59,7 +59,17 @@ module Sord
         count_object
 
         parameter_list = meth.parameters.map do |name, default|
-          "#{name}#{default && " = #{default}"}"
+          # Handle these three main cases:
+          # - def method(param) or def method(param:)
+          # - def method(param: 'default')
+          # - def method(param = 'default')
+          if default.nil?
+            "#{name}"
+          elsif !default.nil? && name.end_with?(':')
+            "#{name} #{default}"
+          else
+            "#{name} = #{default}"
+          end
         end.join(", ")
 
         # This is better than iterating over YARD's "@param" tags directly 


### PR DESCRIPTION
Input:

```ruby
def add_field(name: nil, value: nil, inline: nil)
  # code
end
```

Output:
```ruby
# Before
def add_field(name: = nil, value: = nil, inline: = nil) end

# After
def add_field(name: nil, value: nil, inline: nil) end
```

Fixes #7.

This doesn't add tests because I couldn't really figure out a good way to do it, short of giving the tests some manually-crafted YARD objects or having fixture files. I'll let you decide how you want to handle that.