### PR TITLE
Fix keyword arguments in signatures.

### DIFF
--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -88,9 +88,13 @@ module Sord
               getter.tags('return').flat_map(&:types), meth)
             
             Logging.infer("inferred type of parameter #{name.inspect} as #{inferred_type} using getter's return type", meth)
+            # Get rid of : on keyword arguments.
+            name = name.chop if name.end_with?(':')
             "#{name}: #{inferred_type}"
           else
             Logging.omit("no YARD type given for #{name.inspect}, using T.untyped", meth)
+            # Get rid of : on keyword arguments.
+            name = name.chop if name.end_with?(':')
             "#{name}: T.untyped"
           end
         end.join(", ")


### PR DESCRIPTION
Input:

```ruby
# Blah
# @param name [String] The field's name
# @param value [String] The field's value
# @param inline [true, false] Whether the field should be inlined
def add_field(name: nil, value: nil, inline: nil)
  # code
end
```

Output:

```ruby
# Before
sig { params(name:: T.untyped, value:: T.untyped, inline:: T.untyped).void }

# After
sig { params(name: T.untyped, value: T.untyped, inline: T.untyped).void }
```

Fixes #8.