### PR TITLE
Cut ampersand from block parameter name in signature.

### DIFF
--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -84,6 +84,9 @@ module Sord
           elsif name.start_with? '*'
             # TODO: is there a YARD definition for this?
             "args: T::Array[T.any]"
+          elsif name.start_with? '&'
+            # Cut the ampersand from the block parameter name.
+            "#{name[1..-1]}: T.untyped"
           elsif meth.path.end_with? '='
             # Look for the matching getter method
             getter_path = meth.path[0...-1]


### PR DESCRIPTION
Fixes #14. I'm pretty much just interested in getting it to a valid state, in the future sord should definitely infer better typing from other info in the YARD docs.

```ruby
# Before
sig { params(name: T.any(Symbol, T::Array[Symbol]), attributes: Hash, &block: T.untyped).returns(Command) }
def command(name, attributes = {}, &block); end

# After
sig { params(name: T.any(Symbol, T::Array[Symbol]), attributes: Hash, block: T.untyped).returns(Command) }
def command(name, attributes = {}, &block); end
```