### PR TITLE
Handle hash rocket syntax for hash type definitions.

### DIFF
--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -11,9 +11,10 @@ module Sord
 
     # A regular expression which matches a Ruby namespace immediately followed
     # by another Ruby namespace in angle brackets. This is the format usually
-    # used in YARD to model generic types, such as "Array<String>".
+    # used in YARD to model generic types, such as "Array<String>",
+    # "Hash<String, Symbol>", Hash{String => Symbol}, etc.
     GENERIC_TYPE_REGEX =
-      /(#{SIMPLE_TYPE_REGEX})\s*<\s*(.*)\s*>/
+      /(#{SIMPLE_TYPE_REGEX})\s*[<{]\s*(.*)\s*[>}]/
 
     # An array of built-in generic types supported by Sorbet.
     SORBET_SUPPORTED_GENERIC_TYPES = %w{Array Set Enumerable Enumerator Range Hash}
@@ -31,11 +32,24 @@ module Sord
       while character_pointer < params.length
         should_buffer = true
 
-        current_bracketing_level += 1 if params[character_pointer] == ?<
-        current_bracketing_level -= 1 if params[character_pointer] == ?>
+        current_bracketing_level += 1 if params[character_pointer] == '<'
+        current_bracketing_level -= 1 if params[character_pointer] == '>'
 
-        if params[character_pointer] == ?,
+        # Handle commas as separators.
+        # e.g. Hash<Symbol, String>
+        if params[character_pointer] == ','
           if current_bracketing_level == 0
+            result << buffer.strip
+            buffer = ""
+            should_buffer = false
+          end
+        end
+
+        # Handle hash rockets as separators.
+        # e.g. Hash<Symbol => String>
+        if params[character_pointer] == '=' && params[character_pointer + 1] == '>'
+          if current_bracketing_level == 0
+            character_pointer += 1
             result << buffer.strip
             buffer = ""
             should_buffer = false
@@ -47,6 +61,8 @@ module Sord
       end
 
       result << buffer.strip
+
+      puts result.inspect
 
       result
     end

--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -32,8 +32,11 @@ module Sord
       while character_pointer < params.length
         should_buffer = true
 
-        current_bracketing_level += 1 if params[character_pointer] == '<'
-        current_bracketing_level -= 1 if params[character_pointer] == '>'
+        current_bracketing_level += 1 if ['<', '{'].include?(params[character_pointer])
+        # Decrease bracketing level by 1 when encountering `>` or `}`, unless
+        # the previous character is `=` (to prevent hash rockets from causing
+        # nesting problems).
+        current_bracketing_level -= 1 if ['>', '}'].include?(params[character_pointer]) && params[character_pointer - 1] != '='
 
         # Handle commas as separators.
         # e.g. Hash<Symbol, String>

--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -12,7 +12,7 @@ module Sord
     # A regular expression which matches a Ruby namespace immediately followed
     # by another Ruby namespace in angle brackets. This is the format usually
     # used in YARD to model generic types, such as "Array<String>",
-    # "Hash<String, Symbol>", Hash{String => Symbol}, etc.
+    # "Hash<String, Symbol>", "Hash{String => Symbol}", etc.
     GENERIC_TYPE_REGEX =
       /(#{SIMPLE_TYPE_REGEX})\s*[<{]\s*(.*)\s*[>}]/
 

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -102,6 +102,8 @@ describe Sord::TypeConverter do
           expect(subject.yard_to_sorbet('Hash<String=>Symbol>')).to eq 'T::Hash[String, Symbol]'
           expect(subject.yard_to_sorbet('Hash{String=>Symbol}')).to eq 'T::Hash[String, Symbol]'
           expect(subject.yard_to_sorbet('Hash{String => Symbol}')).to eq 'T::Hash[String, Symbol]'
+          expect(subject.yard_to_sorbet('Hash<Hash{String => Symbol}, Hash<Array<Symbol>, Integer>>')).to eq \
+            'T::Hash[T::Hash[String, Symbol], T::Hash[T::Array[Symbol], Integer]]'
         end
 
         it 'returns a replacement constant with a warning if it is not a known generic' do

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -97,6 +97,12 @@ describe Sord::TypeConverter do
           expect(subject.yard_to_sorbet('Hash<Hash<String, Symbol>, Hash<Array<Symbol>, Integer>>')).to eq \
             'T::Hash[T::Hash[String, Symbol], T::Hash[T::Array[Symbol], Integer]]'
         end
+        
+        it 'handles correctly-formed two-argument type parameters with hash rockets' do
+          expect(subject.yard_to_sorbet('Hash<String=>Symbol>')).to eq 'T::Hash[String, Symbol]'
+          expect(subject.yard_to_sorbet('Hash{String=>Symbol}')).to eq 'T::Hash[String, Symbol]'
+          expect(subject.yard_to_sorbet('Hash{String => Symbol}')).to eq 'T::Hash[String, Symbol]'
+        end
 
         it 'returns a replacement constant with a warning if it is not a known generic' do
           expect {

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -104,6 +104,8 @@ describe Sord::TypeConverter do
           expect(subject.yard_to_sorbet('Hash{String => Symbol}')).to eq 'T::Hash[String, Symbol]'
           expect(subject.yard_to_sorbet('Hash<Hash{String => Symbol}, Hash<Array<Symbol>, Integer>>')).to eq \
             'T::Hash[T::Hash[String, Symbol], T::Hash[T::Array[Symbol], Integer]]'
+          expect(subject.yard_to_sorbet('Hash{Hash{String => Symbol} => Hash{Array<Symbol> => Integer}}')).to eq \
+            'T::Hash[T::Hash[String, Symbol], T::Hash[T::Array[Symbol], Integer]]'
         end
 
         it 'returns a replacement constant with a warning if it is not a known generic' do


### PR DESCRIPTION
See #3.

e.g. `Hash{String => Symbol}` or `Hash<String => Symbol>`.

This was easier than expected, which definitely means I messed something up.

I also converted the string literals using the `?` syntax (`?<`) to normal strings since I think that's easier to read. I can revert it if you want.

Adds tests for the changes. I haven't tried using this with nested hash rockets, so I'm not entirely sure whether that'll work.