### PR TITLE
'ducl' => 'duck'

### DIFF
--- a/lib/sord/logging.rb
+++ b/lib/sord/logging.rb
@@ -61,7 +61,7 @@ module Sord
     #  is associated with, if any. This is shown before the log message if it is
     #  specified.
     def self.duck(msg, item=nil)
-      generic(:ducl, '[DUCK ]'.cyan, msg, item)
+      generic(:duck, '[DUCK ]'.cyan, msg, item)
     end
 
     # Print an error message. This should be used for things which require the


### PR DESCRIPTION
Fix a typo.