### PR TITLE
Change item.path colorization to bold.

### DIFF
--- a/lib/sord/logging.rb
+++ b/lib/sord/logging.rb
@@ -35,7 +35,7 @@ module Sord
     #  specified.
     def self.generic(kind, header, msg, item)
       if item
-        puts "#{header} (#{item.path.light_white}) #{msg}" unless silent?
+        puts "#{header} (#{item.path.bold}) #{msg}" unless silent?
       else
         puts "#{header} #{msg}" unless silent?
       end

--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -175,7 +175,7 @@ module Sord
     rescue
       Logging.error($!)
       $@.each do |line|
-        puts "         #{line}".light_white
+        puts "         #{line}"
       end
     end
   end


### PR DESCRIPTION
And remove white colorization on rbi_generator backtrace.

Let it use the default text color for both.

Fixes #27.

Before:
<img width="1552" alt="Screen Shot 2019-06-22 at 9 10 26 PM" src="https://user-images.githubusercontent.com/2977353/59971165-42056a80-9534-11e9-8e25-9a1d535d9566.png">

After:
<img width="1552" alt="Screen Shot 2019-06-22 at 9 24 57 PM" src="https://user-images.githubusercontent.com/2977353/59971161-34e87b80-9534-11e9-93e2-00144d88bbcc.png">

And it also looks essentially the same as before in my dark-themed VSCode terminal :)