### PR TITLE
Handle duck types with more than one method.

### DIFF
--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -16,6 +16,11 @@ module Sord
     # "Hash<String, Symbol>", "Hash{String => Symbol}", etc.
     GENERIC_TYPE_REGEX =
       /(#{SIMPLE_TYPE_REGEX})\s*[<{]\s*(.*)\s*[>}]/
+    
+    # Match duck types which require the object implement one or more methods,
+    # like '#foo', '#foo & #bar', '#foo&#bar&#baz', and '#foo&#bar&#baz&#foo_bar'.
+    DUCK_TYPE_REGEX =
+      /^\##{SIMPLE_TYPE_REGEX}(?:( ?\& ?\#)*[a-zA-Z_][a-zA-Z_0-9]*)*$/
 
     # An array of built-in generic types supported by Sorbet.
     SORBET_SUPPORTED_GENERIC_TYPES = %w{Array Set Enumerable Enumerator Range Hash}
@@ -99,7 +104,7 @@ module Sord
           Logging.warn("#{yard} is probably not a type, but using anyway", item)
         end
         yard
-      when /^\##{SIMPLE_TYPE_REGEX}$/
+      when DUCK_TYPE_REGEX
         Logging.duck("#{yard} looks like a duck type, replacing with T.untyped", item)
         'T.untyped'
       when /^#{GENERIC_TYPE_REGEX}$/

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -68,6 +68,9 @@ describe Sord::TypeConverter do
 
       it 'converts duck types to T.untyped' do
         expect(subject.yard_to_sorbet('#to_s')).to eq 'T.untyped'
+        expect(subject.yard_to_sorbet('#foo & #bar')).to eq 'T.untyped'
+        expect(subject.yard_to_sorbet('#foo & #foo_bar & #baz')).to eq 'T.untyped'
+        expect(subject.yard_to_sorbet('#foo&#bar')).to eq 'T.untyped'
       end
 
       it 'supports self' do

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -73,6 +73,10 @@ describe Sord::TypeConverter do
         expect(subject.yard_to_sorbet('#foo&#bar')).to eq 'T.untyped'
       end
 
+      it 'does not convert invalid duck types' do
+        expect(subject.yard_to_sorbet('#foo&bar')).to eq 'SORD_ERROR_foobar'
+      end
+
       it 'supports self' do
         # Create a stub object which partially behaves like a CodeObject method
         stub_method = Module.new do


### PR DESCRIPTION
e.g. `#foo & #bar`

Here's a regex101 showing how this works: https://regex101.com/r/ZQNLW2/1

Do you ever write a regex and think "oh I've gone too far this time"? Yeah.

Fixes a weird edge case for #15.