### PR TITLE
Handles order-dependent YARD arrays and converts them to Sorbet tuples.

### DIFF
--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -8,14 +8,19 @@ module Sord
     # "Foo", "Foo::Bar", and "::Foo::Bar" are all matches, whereas "Foo.Bar"
     # or "Foo#bar" are not.
     SIMPLE_TYPE_REGEX =
-      /(?:\:\:)?[a-zA-Z_][a-zA-Z_0-9]*(?:\:\:[a-zA-Z_][a-zA-Z_0-9]*)*/
+      /(?:\:\:)?[a-zA-Z_][\w]*(?:\:\:[a-zA-Z_][\w]*)*/
 
     # A regular expression which matches a Ruby namespace immediately followed
-    # by another Ruby namespace in angle brackets. This is the format usually
-    # used in YARD to model generic types, such as "Array<String>",
-    # "Hash<String, Symbol>", "Hash{String => Symbol}", etc.
+    # by another Ruby namespace in angle brackets or curly braces.
+    # This is the format usually used in YARD to model generic
+    # types, such as "Array<String>", "Hash<String, Symbol>",
+    # "Hash{String => Symbol}", etc.
     GENERIC_TYPE_REGEX =
-      /(#{SIMPLE_TYPE_REGEX})\s*[<{]\s*(.*)\s*[>}]/
+      /^(#{SIMPLE_TYPE_REGEX})\s*[<{]\s*(.*)\s*[>}]$/
+    
+    # A regular expression which matches ordered lists in the format of
+    # either "Array(String, Symbol)" or "(String, Symbol)".
+    ORDERED_LIST_REGEX = /^(?:Array|)\((.*)\s*\)$/
 
     # An array of built-in generic types supported by Sorbet.
     SORBET_SUPPORTED_GENERIC_TYPES = %w{Array Set Enumerable Enumerator Range Hash}
@@ -34,11 +39,11 @@ module Sord
       while character_pointer < params.length
         should_buffer = true
 
-        current_bracketing_level += 1 if ['<', '{'].include?(params[character_pointer])
+        current_bracketing_level += 1 if ['<', '{', '('].include?(params[character_pointer])
         # Decrease bracketing level by 1 when encountering `>` or `}`, unless
         # the previous character is `=` (to prevent hash rockets from causing
         # nesting problems).
-        current_bracketing_level -= 1 if ['>', '}'].include?(params[character_pointer]) && params[character_pointer - 1] != '='
+        current_bracketing_level -= 1 if ['>', '}', ')'].include?(params[character_pointer]) && params[character_pointer - 1] != '='
 
         # Handle commas as separators.
         # e.g. Hash<Symbol, String>
@@ -102,7 +107,7 @@ module Sord
       when /^\##{SIMPLE_TYPE_REGEX}$/
         Logging.duck("#{yard} looks like a duck type, replacing with T.untyped", item)
         'T.untyped'
-      when /^#{GENERIC_TYPE_REGEX}$/
+      when GENERIC_TYPE_REGEX
         generic_type = $1
         type_parameters = $2
 
@@ -118,6 +123,13 @@ module Sord
           Logging.warn("unsupported generic type #{generic_type.inspect} in #{yard.inspect}", item)
           "SORD_ERROR_#{generic_type.gsub(/[^0-9A-Za-z_]/i, '')}"
         end
+      # Converts ordered lists like Array(Symbol, String) or (Symbol, String)
+      # into Sorbet Tuples like [Symbol, String].
+      when ORDERED_LIST_REGEX
+        type_parameters = $1
+        parameters = split_type_parameters(type_parameters)
+          .map { |x| yard_to_sorbet(x, item) }
+        "[#{parameters.join(', ')}]"
       else
         # Check for literals
         from_yaml = YAML.load(yard) rescue nil

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -120,6 +120,18 @@ describe Sord::TypeConverter do
             expect(subject.yard_to_sorbet('Foo<String>')).to eq 'SORD_ERROR_Foo'
           }.to log :warn
         end
+
+        it 'handles order-dependent lists by returning Tuples' do
+          expect(subject.yard_to_sorbet('Array(String, Integer)')).to eq '[String, Integer]'
+          expect(subject.yard_to_sorbet('Array(Integer, Integer)')).to eq '[Integer, Integer]'
+          expect(subject.yard_to_sorbet('Array(Fixnum, String, Symbol, Integer)')).to eq '[Fixnum, String, Symbol, Integer]'
+          expect(subject.yard_to_sorbet('(String, Integer)')).to eq '[String, Integer]'
+        end
+
+        it 'handles nested order-dependent lists by returning nested Tuples' do
+          expect(subject.yard_to_sorbet('(String, Symbol, Array(String, Symbol))')).to eq '[String, Symbol, [String, Symbol]]'
+          expect(subject.yard_to_sorbet('(String, Symbol, (String, Symbol))')).to eq '[String, Symbol, [String, Symbol]]'
+        end
       end
     end
   end


### PR DESCRIPTION
Implements #37.

I'm not sure if the `Array<(Symbol, String)>` syntax is actually valid as used in the YARD documentation, but if it is I can add it. Modifying the nesting parser to include parenthesis is necessary to support nested tuples.

This also simplifies `a-zA-Z_0-9` in the regex to the equivalent shorthand `\w`.