### PR TITLE
Remove string from literal types to fix false-positives.

### DIFF
--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -122,7 +122,7 @@ module Sord
         # Check for literals
         from_yaml = YAML.load(yard) rescue nil
         return from_yaml.class.to_s \
-          if [Symbol, String, Float, Integer].include?(from_yaml.class)
+          if [Symbol, Float, Integer].include?(from_yaml.class)
 
         Logging.warn("#{yard.inspect} does not appear to be a type", item)
         "SORD_ERROR_#{yard.gsub(/[^0-9A-Za-z_]/i, '')}"

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -63,7 +63,7 @@ describe Sord::TypeConverter do
           'T.any(String, Symbol)'
         expect(subject.yard_to_sorbet('3')).to eq 'Integer'
         expect(subject.yard_to_sorbet('3.14')).to eq 'Float'
-        expect(subject.yard_to_sorbet('\'foo\'')).to eq 'String'
+        # expect(subject.yard_to_sorbet('\'foo\'')).to eq 'String'
       end
 
       it 'converts duck types to T.untyped' do
@@ -119,6 +119,28 @@ describe Sord::TypeConverter do
           expect {
             expect(subject.yard_to_sorbet('Foo<String>')).to eq 'SORD_ERROR_Foo'
           }.to log :warn
+        end
+      end
+
+      context 'invalid YARD docs' do
+        it 'SORD_ERROR for invalid duck types' do
+          expect(subject.yard_to_sorbet('foo&bar')).to eq 'SORD_ERROR_foobar'
+          expect(subject.yard_to_sorbet('foo&#bar')).to eq 'SORD_ERROR_foobar'
+          expect(subject.yard_to_sorbet('#foo&bar')).to eq 'SORD_ERROR_foobar'
+        end
+
+        it 'SORD_ERROR for invalid hashes with uneven curly braces' do
+          expect(subject.yard_to_sorbet('Hash{String, Symbol')).to eq 'SORD_ERROR_HashStringSymbol'
+          expect(subject.yard_to_sorbet('Hash{String')).to eq 'SORD_ERROR_HashString'
+        end
+        
+        it 'SORD_ERROR for invalid Arrays with uneven angle brackets' do
+          expect(subject.yard_to_sorbet('Array<String, Symbol')).to eq 'SORD_ERROR_ArrayStringSymbol'
+          expect(subject.yard_to_sorbet('Array<String')).to eq 'SORD_ERROR_ArrayString'
+        end
+        
+        it 'SORD_ERROR for a type list not inside a container' do
+          expect(subject.yard_to_sorbet('String, Symbol')).to eq 'SORD_ERROR_StringSymbol'
         end
       end
     end


### PR DESCRIPTION
I noticed in https://github.com/AaronC81/sord/issues/37#issuecomment-504799832 that the change from https://github.com/AaronC81/sord/commit/a824f0f94a1deda76fa067929b2f54eef92c26aa causes many invalid (or currently unhandled) YARD docs to be parsed as Strings, which can create a lot of invalid Sorbet signatures and incorrectly decreases the number of SORD_ERRORs in a generated file.

Add tests that validate this behavior to make sure it can't regress. Unfortunately, I had to disable a String test as well. If you have any ideas for making this work better without causing any false-positives, I'd be happy to hear it.