### PR TITLE
Update duck type regex to allow setter duck types.

### DIFF
--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -21,7 +21,7 @@ module Sord
     # Match duck types which require the object implement one or more methods,
     # like '#foo', '#foo & #bar', '#foo&#bar&#baz', and '#foo&#bar&#baz&#foo_bar'.
     DUCK_TYPE_REGEX =
-      /^\#[a-zA-Z_][\w]*(?:[a-zA-Z_][\w=]*)*(?:( ?\& ?\#)*[a-zA-Z_][a-zA-Z_0-9]*)*$/
+      /^\#[a-zA-Z_][\w]*(?:[a-zA-Z_][\w=]*)*(?:( ?\& ?\#)*[a-zA-Z_][\w=]*)*$/
     
     # A regular expression which matches ordered lists in the format of
     # either "Array(String, Symbol)" or "(String, Symbol)".

--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -21,7 +21,7 @@ module Sord
     # Match duck types which require the object implement one or more methods,
     # like '#foo', '#foo & #bar', '#foo&#bar&#baz', and '#foo&#bar&#baz&#foo_bar'.
     DUCK_TYPE_REGEX =
-      /^\##{SIMPLE_TYPE_REGEX}(?:( ?\& ?\#)*[a-zA-Z_][a-zA-Z_0-9]*)*$/
+      /^\#[a-zA-Z_][\w]*(?:[a-zA-Z_][\w=]*)*(?:( ?\& ?\#)*[a-zA-Z_][a-zA-Z_0-9]*)*$/
     
     # A regular expression which matches ordered lists in the format of
     # either "Array(String, Symbol)" or "(String, Symbol)".

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -72,6 +72,7 @@ describe Sord::TypeConverter do
         expect(subject.yard_to_sorbet('#foo & #bar')).to eq 'T.untyped'
         expect(subject.yard_to_sorbet('#foo & #foo_bar & #baz')).to eq 'T.untyped'
         expect(subject.yard_to_sorbet('#foo&#bar')).to eq 'T.untyped'
+        expect(subject.yard_to_sorbet('#foo & #setter=')).to eq 'T.untyped'
       end
 
       it 'does not convert invalid duck types' do

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -68,6 +68,7 @@ describe Sord::TypeConverter do
 
       it 'converts duck types to T.untyped' do
         expect(subject.yard_to_sorbet('#to_s')).to eq 'T.untyped'
+        expect(subject.yard_to_sorbet('#setter=')).to eq 'T.untyped'
         expect(subject.yard_to_sorbet('#foo & #bar')).to eq 'T.untyped'
         expect(subject.yard_to_sorbet('#foo & #foo_bar & #baz')).to eq 'T.untyped'
         expect(subject.yard_to_sorbet('#foo&#bar')).to eq 'T.untyped'
@@ -146,6 +147,8 @@ describe Sord::TypeConverter do
           expect(subject.yard_to_sorbet('foo&bar')).to eq 'SORD_ERROR_foobar'
           expect(subject.yard_to_sorbet('foo&#bar')).to eq 'SORD_ERROR_foobar'
           expect(subject.yard_to_sorbet('#foo&bar')).to eq 'SORD_ERROR_foobar'
+          expect(subject.yard_to_sorbet('#foo-bar')).to eq 'SORD_ERROR_foobar'
+          expect(subject.yard_to_sorbet('#=foobar')).to eq 'SORD_ERROR_foobar'
         end
 
         it 'SORD_ERROR for invalid hashes with uneven curly braces' do


### PR DESCRIPTION
Also add a test to make sure dashes aren't valid in duck type methods and that methods can't start with an =.

I noticed this when running on the YARD codebase itself :) Lots of the SORD_ERRORs were caused by `#visibility=`.