### PR TITLE
Add examples:seed Rake task.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 .rspec_status
 .vscode/
 Gemfile.lock
+
+sord_examples/

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,18 @@ RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
 
+REPOS = {
+  discordrb: 'https://github.com/meew0/discordrb',
+  rouge: 'https://github.com/rouge-ruby/rouge',
+  yard: 'https://github.com/lsegal/yard',
+  addressable: 'https://github.com/sporkmonger/addressable',
+  zeitwerk: 'https://github.com/fxn/zeitwerk',
+  'rspec-core': 'https://github.com/rspec/rspec-core',
+  bundler: 'https://github.com/bundler/bundler',
+  haml: 'https://github.com/haml/haml',
+  gitlab: 'https://github.com/NARKOZ/gitlab'
+}
+
 namespace :examples do
   desc "Clone git repositories and run Sord on them as examples"
   task :seed do
@@ -12,26 +24,15 @@ namespace :examples do
     require 'colorize'
 
     if File.directory?('sord_examples')
-      puts 'sord_examples directory already exists, please delete the directory before seeding!'.red
+      puts 'sord_examples directory already exists, please delete the directory before seeding, or run a reseed!'.red
       exit
     end
 
     FileUtils.mkdir 'sord_examples'
     FileUtils.cd 'sord_examples'
-    repos = {
-      discordrb: 'https://github.com/meew0/discordrb',
-      rouge: 'https://github.com/rouge-ruby/rouge',
-      yard: 'https://github.com/lsegal/yard',
-      addressable: 'https://github.com/sporkmonger/addressable',
-      zeitwerk: 'https://github.com/fxn/zeitwerk',
-      'rspec-core': 'https://github.com/rspec/rspec-core',
-      bundler: 'https://github.com/bundler/bundler',
-      haml: 'https://github.com/haml/haml',
-      gitlab: 'https://github.com/NARKOZ/gitlab'
-    }
 
     # Shallow clone each of the repositories and then bundle install and run sord.
-    repos.each do |name, url|
+    REPOS.each do |name, url|
       puts "Cloning #{name}..."
       `git clone #{url} --depth=1`
       FileUtils.cd name.to_s
@@ -49,6 +50,19 @@ namespace :examples do
     puts "Seeding complete!"
   end
 
+  desc 'Regenerate the rbi files in sord_examples.'
+  task :reseed do
+    require 'fileutils'
+
+    FileUtils.cd 'sord_examples'
+    REPOS.keys.each do |name|
+      FileUtils.cd name.to_s
+      puts "Regenerating rbi file for #{name}..."
+      `bundle exec sord ../#{name}.rbi --no-regenerate`
+      FileUtils.cd '..'
+    end
+  end
+  
   desc 'Delete the sord_examples directory to allow the seeder to run again.'
   task :reset do
     require 'fileutils'

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,56 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+namespace :examples do
+  desc "Clone git repositories and run Sord on them as examples"
+  task :seed do
+    require 'fileutils'
+    require 'colorize'
+
+    if File.directory?('sord_examples')
+      puts 'sord_examples directory already exists, please delete the directory before seeding!'.red
+      exit
+    end
+
+    FileUtils.mkdir 'sord_examples'
+    FileUtils.cd 'sord_examples'
+    repos = {
+      discordrb: 'https://github.com/meew0/discordrb',
+      rouge: 'https://github.com/rouge-ruby/rouge',
+      yard: 'https://github.com/lsegal/yard',
+      addressable: 'https://github.com/sporkmonger/addressable',
+      zeitwerk: 'https://github.com/fxn/zeitwerk',
+      'rspec-core': 'https://github.com/rspec/rspec-core',
+      bundler: 'https://github.com/bundler/bundler',
+      haml: 'https://github.com/haml/haml',
+      gitlab: 'https://github.com/NARKOZ/gitlab'
+    }
+
+    # Shallow clone each of the repositories and then bundle install and run sord.
+    repos.each do |name, url|
+      puts "Cloning #{name}..."
+      `git clone #{url} --depth=1`
+      FileUtils.cd name.to_s
+      # Add sord to gemfile.
+      `echo "gem 'sord', path: '../../'" >> Gemfile`
+      # Run bundle install.
+      `bundle install`
+      # Generate sri
+      puts "Generating rbi for #{name}..."
+      `bundle exec sord ../#{name}.rbi`
+      puts "#{name}.rbi generated!"
+      FileUtils.cd '..'
+    end
+
+    puts "Seeding complete!"
+  end
+
+  desc 'Delete the sord_examples directory to allow the seeder to run again.'
+  task :reset do
+    require 'fileutils'
+ 
+    FileUtils.rm_rf 'sord_examples' if File.directory?('sord_examples')
+  end
+end
+

--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,7 @@ namespace :examples do
     REPOS.keys.each do |name|
       FileUtils.cd name.to_s
       puts "Regenerating rbi file for #{name}..."
-      `bundle exec sord ../#{name}.rbi --no-regenerate`
+      system("bundle exec sord ../#{name}.rbi --no-regenerate")
       FileUtils.cd '..'
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -61,6 +61,8 @@ namespace :examples do
       `bundle exec sord ../#{name}.rbi --no-regenerate`
       FileUtils.cd '..'
     end
+    
+    puts "Re-seeding complete!"
   end
   
   desc 'Delete the sord_examples directory to allow the seeder to run again.'

--- a/Rakefile
+++ b/Rakefile
@@ -6,21 +6,22 @@ RSpec::Core::RakeTask.new(:spec)
 task :default => :spec
 
 REPOS = {
-  discordrb: 'https://github.com/meew0/discordrb',
-  rouge: 'https://github.com/rouge-ruby/rouge',
-  yard: 'https://github.com/lsegal/yard',
   addressable: 'https://github.com/sporkmonger/addressable',
-  zeitwerk: 'https://github.com/fxn/zeitwerk',
-  'rspec-core': 'https://github.com/rspec/rspec-core',
   bundler: 'https://github.com/bundler/bundler',
+  discordrb: 'https://github.com/meew0/discordrb',
+  gitlab: 'https://github.com/NARKOZ/gitlab',
   haml: 'https://github.com/haml/haml',
-  gitlab: 'https://github.com/NARKOZ/gitlab'
+  rouge: 'https://github.com/rouge-ruby/rouge',
+  'rspec-core': 'https://github.com/rspec/rspec-core',
+  yard: 'https://github.com/lsegal/yard',
+  zeitwerk: 'https://github.com/fxn/zeitwerk'
 }
 
 namespace :examples do
+  require 'fileutils'
+
   desc "Clone git repositories and run Sord on them as examples"
   task :seed do
-    require 'fileutils'
     require 'colorize'
 
     if File.directory?('sord_examples')
@@ -52,8 +53,6 @@ namespace :examples do
 
   desc 'Regenerate the rbi files in sord_examples.'
   task :reseed do
-    require 'fileutils'
-
     FileUtils.cd 'sord_examples'
     REPOS.keys.each do |name|
       FileUtils.cd name.to_s
@@ -61,15 +60,14 @@ namespace :examples do
       `bundle exec sord ../#{name}.rbi --no-regenerate`
       FileUtils.cd '..'
     end
-    
+
     puts "Re-seeding complete!"
   end
   
   desc 'Delete the sord_examples directory to allow the seeder to run again.'
   task :reset do
-    require 'fileutils'
- 
     FileUtils.rm_rf 'sord_examples' if File.directory?('sord_examples')
+    puts 'Reset complete.'
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ namespace :examples do
     # Shallow clone each of the repositories and then bundle install and run sord.
     REPOS.each do |name, url|
       puts "Cloning #{name}..."
-      `git clone #{url} --depth=1`
+      system("git clone #{url} --depth=1")
       FileUtils.cd name.to_s
       # Add sord to gemfile.
       `echo "gem 'sord', path: '../../'" >> Gemfile`
@@ -43,7 +43,7 @@ namespace :examples do
       `bundle install`
       # Generate sri
       puts "Generating rbi for #{name}..."
-      `bundle exec sord ../#{name}.rbi`
+      system("bundle exec sord ../#{name}.rbi")
       puts "#{name}.rbi generated!"
       FileUtils.cd '..'
     end


### PR DESCRIPTION
`bundle exec rake examples:seed`

I got tired of manually doing this to test sord, so I threw together a little Rake task to do it for me. This task will clone some git repos for gems that have YARD docs and then run sord and generate the rbi files for each.

This also includes an `examples:reset` Rake task to delete the `sord_examples` directory.

~~This can probably be made much more efficient by adding an `examples:reseed` task that'll just re-run sord for each of these repos without changing anything else. Right now, you have to reset between each seeding to make it work.~~ There's now an `examples:reseed` task to quickly rerun sord on each of these projects :)