### PR TITLE
Print extends and includes in reverse order.

### DIFF
--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -79,10 +79,10 @@ module Sord
       includes = item.instance_mixins
       extends = item.class_mixins
 
-      extends.each do |this_extend|
+      extends.reverse_each do |this_extend|
         rbi_contents << "#{'  ' * (indent_level + 1)}extend #{this_extend.path}"
       end
-      includes.each do |this_include|
+      includes.reverse_each do |this_include|
         rbi_contents << "#{'  ' * (indent_level + 1)}include #{this_include.path}"
       end
 

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -194,6 +194,37 @@ describe Sord::RbiGenerator do
     EOF
   end
 
+
+  it 'generates extends in the same order as they were in the original file' do
+    YARD.parse_string(<<-EOF)
+      class A; end
+      class B; end
+      class C; end
+
+      class D < A
+        extend C
+        extend B
+      end
+    EOF
+
+    expect(subject.generate.strip).to eq fix_heredoc(<<-EOF)
+      # typed: strong
+      class A
+      end
+
+      class B
+      end
+
+      class C
+      end
+
+      class D < A
+        extend C
+        extend B
+      end
+    EOF
+  end
+
   it 'generates blocks correctly' do
     YARD.parse_string(<<-EOF)
       module A

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -164,6 +164,36 @@ describe Sord::RbiGenerator do
     EOF
   end
 
+  it 'generates includes in the same order as they were in the original file' do
+    YARD.parse_string(<<-EOF)
+      class A; end
+      class B; end
+      class C; end
+
+      class D < A
+        include C
+        include B
+      end
+    EOF
+
+    expect(subject.generate.strip).to eq fix_heredoc(<<-EOF)
+      # typed: strong
+      class A
+      end
+
+      class B
+      end
+
+      class C
+      end
+
+      class D < A
+        include C
+        include B
+      end
+    EOF
+  end
+
   it 'generates blocks correctly' do
     YARD.parse_string(<<-EOF)
       module A


### PR DESCRIPTION
~~They're initially returned alphabetically backwards, so we need to reverse them to get them to sort alphabetically.~~ They should be ordered in the same way as the original file, while currently they're ordered backwards.

You can see this best in `gitlab.rbi`.

Before:

```ruby
include Gitlab::Client::Wikis
include Gitlab::Client::Versions
include Gitlab::Client::Users
include Gitlab::Client::Todos
include Gitlab::Client::Templates
include Gitlab::Client::Tags
include Gitlab::Client::SystemHooks
include Gitlab::Client::Snippets
include Gitlab::Client::Sidekiq
include Gitlab::Client::Services
include Gitlab::Client::Search
include Gitlab::Client::Runners
include Gitlab::Client::ResourceLabelEvents
include Gitlab::Client::RepositorySubmodules
include Gitlab::Client::RepositoryFiles
include Gitlab::Client::Repositories
include Gitlab::Client::ProtectedTags
include Gitlab::Client::Projects
include Gitlab::Client::ProjectReleases
include Gitlab::Client::ProjectReleaseLinks
include Gitlab::Client::ProjectClusters
include Gitlab::Client::ProjectBadges
include Gitlab::Client::Pipelines
include Gitlab::Client::PipelineTriggers
include Gitlab::Client::PipelineSchedules
include Gitlab::Client::Notes
include Gitlab::Client::Namespaces
include Gitlab::Client::Milestones
include Gitlab::Client::MergeRequests
include Gitlab::Client::MergeRequestApprovals
include Gitlab::Client::Markdown
include Gitlab::Client::Lint
include Gitlab::Client::Labels
include Gitlab::Client::Keys
include Gitlab::Client::Jobs
include Gitlab::Client::Issues
include Gitlab::Client::Groups
include Gitlab::Client::GroupMilestones
include Gitlab::Client::GroupLabels
include Gitlab::Client::GroupBoards
include Gitlab::Client::Features
include Gitlab::Client::Events
include Gitlab::Client::Environments
include Gitlab::Client::Deployments
include Gitlab::Client::ContainerRegistry
include Gitlab::Client::Commits
include Gitlab::Client::Builds
include Gitlab::Client::BuildVariables
include Gitlab::Client::BroadcastMessages
include Gitlab::Client::Branches
include Gitlab::Client::Boards
include Gitlab::Client::AwardEmojis
include Gitlab::Client::Avatar
include Gitlab::Client::ApplicationSettings
include Gitlab::Client::AccessRequests
```


After:

```ruby
include Gitlab::Client::AccessRequests
include Gitlab::Client::ApplicationSettings
include Gitlab::Client::Avatar
include Gitlab::Client::AwardEmojis
include Gitlab::Client::Boards
include Gitlab::Client::Branches
include Gitlab::Client::BroadcastMessages
include Gitlab::Client::BuildVariables
include Gitlab::Client::Builds
include Gitlab::Client::Commits
include Gitlab::Client::ContainerRegistry
include Gitlab::Client::Deployments
include Gitlab::Client::Environments
include Gitlab::Client::Events
include Gitlab::Client::Features
include Gitlab::Client::GroupBoards
include Gitlab::Client::GroupLabels
include Gitlab::Client::GroupMilestones
include Gitlab::Client::Groups
include Gitlab::Client::Issues
include Gitlab::Client::Jobs
include Gitlab::Client::Keys
include Gitlab::Client::Labels
include Gitlab::Client::Lint
include Gitlab::Client::Markdown
include Gitlab::Client::MergeRequestApprovals
include Gitlab::Client::MergeRequests
include Gitlab::Client::Milestones
include Gitlab::Client::Namespaces
include Gitlab::Client::Notes
include Gitlab::Client::PipelineSchedules
include Gitlab::Client::PipelineTriggers
include Gitlab::Client::Pipelines
include Gitlab::Client::ProjectBadges
include Gitlab::Client::ProjectClusters
include Gitlab::Client::ProjectReleaseLinks
include Gitlab::Client::ProjectReleases
include Gitlab::Client::Projects
include Gitlab::Client::ProtectedTags
include Gitlab::Client::Repositories
include Gitlab::Client::RepositoryFiles
include Gitlab::Client::RepositorySubmodules
include Gitlab::Client::ResourceLabelEvents
include Gitlab::Client::Runners
include Gitlab::Client::Search
include Gitlab::Client::Services
include Gitlab::Client::Sidekiq
include Gitlab::Client::Snippets
include Gitlab::Client::SystemHooks
include Gitlab::Client::Tags
include Gitlab::Client::Templates
include Gitlab::Client::Todos
include Gitlab::Client::Users
include Gitlab::Client::Versions
include Gitlab::Client::Wikis
```