### PR TITLE
Replace identifiers in HEREDOCs with Ruby.

### DIFF
--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -31,16 +31,16 @@ describe Sord::RbiGenerator do
   end
 
   it 'handles blank module structures' do
-    YARD.parse_string(<<-EOF)
+    YARD.parse_string(<<-RUBY)
       module A
         module B; end
         module C
           module D; end
         end
       end
-    EOF
+    RUBY
 
-    expect(subject.generate.strip).to eq fix_heredoc(<<-EOF)
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       module A
         module B
@@ -51,11 +51,11 @@ describe Sord::RbiGenerator do
           end
         end
       end
-    EOF
+    RUBY
   end
 
   it 'handles structures with modules, classes and methods' do
-    YARD.parse_string(<<-EOF)
+    YARD.parse_string(<<-RUBY)
       module A
         class B
           # @return [Integer]
@@ -71,9 +71,9 @@ describe Sord::RbiGenerator do
         module E
         end
       end
-    EOF
+    RUBY
 
-    expect(subject.generate.strip).to eq fix_heredoc(<<-EOF)
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       module A
         class B
@@ -91,11 +91,11 @@ describe Sord::RbiGenerator do
         module E
         end
       end
-      EOF
+      RUBY
   end
   
   it 'auto-generates T.untyped signatures when unspecified and warns' do
-    YARD.parse_string(<<-EOF)
+    YARD.parse_string(<<-RUBY)
       module A
         class B
           def foo; end
@@ -106,9 +106,9 @@ describe Sord::RbiGenerator do
           end
         end
       end
-    EOF
+    RUBY
 
-    expect(subject.generate.strip).to eq fix_heredoc(<<-EOF)
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       module A
         class B
@@ -126,11 +126,11 @@ describe Sord::RbiGenerator do
           end
         end
       end
-      EOF
+      RUBY
   end
 
   it 'generates inheritance, inclusion and extension' do
-    YARD.parse_string(<<-EOF)
+    YARD.parse_string(<<-RUBY)
       class A; end
       class B; end
       class C; end
@@ -140,9 +140,9 @@ describe Sord::RbiGenerator do
         include C
         def x; end
       end
-    EOF
+    RUBY
 
-    expect(subject.generate.strip).to eq fix_heredoc(<<-EOF)
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       class A
       end
@@ -161,11 +161,11 @@ describe Sord::RbiGenerator do
         sig { returns(T.untyped) }
         def x(); end
       end
-    EOF
+    RUBY
   end
 
   it 'generates blocks correctly' do
-    YARD.parse_string(<<-EOF)
+    YARD.parse_string(<<-RUBY)
       module A
         # @param [String] x
         # @return [Boolean]
@@ -174,38 +174,38 @@ describe Sord::RbiGenerator do
         # @yieldreturn [Boolean] c
         def foo(x, &blk); end
       end
-    EOF
+    RUBY
 
-    expect(subject.generate.strip).to eq fix_heredoc(<<-EOF)
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       module A
         sig { params(x: String, blk: T.proc.params(a: Integer, b: Float).returns(T::Boolean)).returns(T::Boolean) }
         def foo(x, &blk); end
       end
-    EOF
+    RUBY
   end
 
   it 'generates varargs correctly' do
-    YARD.parse_string(<<-EOF)
+    YARD.parse_string(<<-RUBY)
       module A
         # @param [Integer] x
         # @param [Array<String>] y
         # @return [void]
         def foo(x, *y); end
       end
-    EOF
+    RUBY
 
-    expect(subject.generate.strip).to eq fix_heredoc(<<-EOF)
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       module A
         sig { params(x: Integer, y: T::Array[String]).void }
         def foo(x, *y); end
       end
-    EOF
+    RUBY
   end
 
   it 'breaks parameters across multiple lines correctly' do
-    YARD.parse_string(<<-EOF)
+    YARD.parse_string(<<-RUBY)
       module A
         # @param [Integer] a
         # @param [String] b
@@ -214,9 +214,9 @@ describe Sord::RbiGenerator do
         # @return [void]
         def foo(a, b, c, d); end
       end
-    EOF
+    RUBY
 
-    expect(subject.generate.strip).to eq fix_heredoc(<<-EOF)
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       module A
         sig do
@@ -229,20 +229,20 @@ describe Sord::RbiGenerator do
         end
         def foo(a, b, c, d); end
       end
-    EOF
+    RUBY
   end
 
   it 'infers setter types' do
-    YARD.parse_string(<<-EOF)
+    YARD.parse_string(<<-RUBY)
       module A
         # @return [Integer]
         def x; end
 
         def x=(value); end
       end
-    EOF
+    RUBY
 
-    expect(subject.generate.strip).to eq fix_heredoc(<<-EOF)
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       module A
         sig { returns(Integer) }
@@ -253,6 +253,6 @@ describe Sord::RbiGenerator do
         sig { params(value: Integer).returns(T.untyped) }
         def x=(value); end
       end
-    EOF
+    RUBY
   end
 end

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -16,17 +16,17 @@ describe Sord::Resolver do
   end
 
   it 'resolves built-in classes without ambiguity' do
-    YARD.parse_string(<<-EOF)
+    YARD.parse_string(<<-RUBY)
       class A
       end
-    EOF
+    RUBY
 
     subject.prepare
     expect(subject.resolvable?('String', at('A'))).to be true
   end
 
   it 'does not resolve built-in classes with ambiguity' do
-    YARD.parse_string(<<-EOF)
+    YARD.parse_string(<<-RUBY)
       module A
         class String
         end
@@ -34,7 +34,7 @@ describe Sord::Resolver do
         class B
         end
       end
-    EOF
+    RUBY
 
     subject.prepare
     expect(subject.resolvable?('String', at('A::B'))).to be false
@@ -42,7 +42,7 @@ describe Sord::Resolver do
   end
 
   it 'resolves parent modules' do
-    YARD.parse_string(<<-EOF)
+    YARD.parse_string(<<-RUBY)
       module A
         module B
           module C
@@ -51,14 +51,14 @@ describe Sord::Resolver do
           end
         end
       end
-    EOF
+    RUBY
 
     subject.prepare
     expect(subject.resolvable?('B', at('A::B::C::D'))).to be true
   end
 
   it 'resolves siblings of parent modules' do
-    YARD.parse_string(<<-EOF)
+    YARD.parse_string(<<-RUBY)
       module A
         module B
           module C
@@ -70,14 +70,14 @@ describe Sord::Resolver do
         class E
         end
       end
-    EOF
+    RUBY
 
     subject.prepare
     expect(subject.resolvable?('E', at('A::B::C::D'))).to be true
   end
 
   it 'can infer unresolvable module structures without ambiguity' do
-    YARD.parse_string(<<-EOF)
+    YARD.parse_string(<<-RUBY)
       module A
         module B
           module C
@@ -91,7 +91,7 @@ describe Sord::Resolver do
           end
         end
       end
-    EOF
+    RUBY
 
     subject.prepare
     expect(subject.resolvable?('F', at('A::B::C::D'))).to be false
@@ -99,7 +99,7 @@ describe Sord::Resolver do
   end
 
   it 'does not resolve ambiguity' do
-    YARD.parse_string(<<-EOF)
+    YARD.parse_string(<<-RUBY)
       module A
         module B
           module C
@@ -118,7 +118,7 @@ describe Sord::Resolver do
           end
         end
       end
-    EOF
+    RUBY
 
     subject.prepare
     expect(subject.resolvable?('F', at('A::B::C::D'))).to be false


### PR DESCRIPTION
At least in VS Code, the HEREDOCs aren't syntax highlighted unless they have an identifier it can determine the language from.