### PR TITLE
Update seeding tasks in Rakefile.

### DIFF
--- a/exe/sord
+++ b/exe/sord
@@ -26,7 +26,9 @@ command :gen do |c|
     if options.regenerate
       begin
         Sord::Logging.info('Running YARD...')
-        `yard`
+        Bundler.with_clean_env do
+          system('bundle exec yard')
+        end
       rescue Errno::ENOENT
         Sord::Logging.error('The YARD tool could not be found on your PATH.')
         Sord::Logging.error('You may need to run \'gem install yard\'.')


### PR DESCRIPTION
Fixes #54.

- Add oga to list of repositories cloned as part of the seeding.
- Run yard with `bundle exec` for consistency and with `system` so it outputs information to the log. This helps with debugging if something breaks.
- Run commands inside a clean Bundler env so `bundle exec` doesn't cause problems.
- Add some colors to messages output by the Rake tasks.

`haml` and `rouge` now work properly when run with the seeder.

Note that Oga does fail currently (I'm opening a PR in just a second to fix that).

Also, I'm not entirely sure if `Bundler.with_clean_env` will work when running the task with just `rake` (vs. `bundle exec rake`) on Ruby < 2.6, before Bundler was included with Ruby itself.