### PR TITLE
Guard against nil in RbiGenerator.

### DIFF
--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -171,7 +171,7 @@ module Sord
 
             # Create strings
             params_string = yieldparams.map do |param|
-              "#{param.name.gsub('*', '')}: #{TypeConverter.yard_to_sorbet(param.types, meth, indent_level, @replace_errors_with_untyped)}"
+              "#{param.name.gsub('*', '')}: #{TypeConverter.yard_to_sorbet(param.types, meth, indent_level, @replace_errors_with_untyped)}" unless param.name.nil?
             end.join(', ')
             return_string = TypeConverter.yard_to_sorbet(yieldreturn, meth, indent_level, @replace_errors_with_untyped)
 


### PR DESCRIPTION
In some cases, `param.name` in `yieldparams` can be `nil`. I noticed this when running Sord on the oga gem.

https://gitlab.com/yorickpeterse/oga
Before:
```
Generating rbi for oga...
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /Users/connorshea/Programming/sord/sord_examples/oga/oga.gemspec:32.
[INFO ] Running YARD...
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /Users/connorshea/Programming/sord/sord_examples/oga/oga.gemspec:32.
[warn]: In file `./README.md':343: Cannot resolve link to Oga::XML::Parser from text:
        ...{Oga::XML::Parser XML Parser}...
[warn]: In file `./README.md':343: Cannot resolve link to Oga::XML::Parser from text:
        ...{Oga::XML::Parser XML Parser}...
Files:          38
Modules:        13 (    8 undocumented)
Classes:        26 (    2 undocumented)
Constants:      30 (    3 undocumented)
Attributes:     23 (    0 undocumented)
Methods:       293 (    0 undocumented)
 96.62% documented
[OMIT ] (Oga.parse_xml) no YARD type given for "xml", using T.untyped
[OMIT ] (Oga.parse_xml) no YARD type given for "options", using T.untyped
[OMIT ] (Oga.parse_html) no YARD type given for "html", using T.untyped
[OMIT ] (Oga.parse_html) no YARD type given for "options", using T.untyped
[OMIT ] (Oga.sax_parse_xml) no YARD type given for "handler", using T.untyped
[OMIT ] (Oga.sax_parse_xml) no YARD type given for "xml", using T.untyped
[OMIT ] (Oga.sax_parse_xml) no YARD type given for "options", using T.untyped
[OMIT ] (Oga.sax_parse_xml) no YARD return type given, using T.untyped
[OMIT ] (Oga.sax_parse_html) no YARD type given for "handler", using T.untyped
[OMIT ] (Oga.sax_parse_html) no YARD type given for "html", using T.untyped
[OMIT ] (Oga.sax_parse_html) no YARD type given for "options", using T.untyped
[OMIT ] (Oga.sax_parse_html) no YARD return type given, using T.untyped
[OMIT ] (Oga::LRU#maximum=) no YARD return type given, using T.untyped
[WARN ] (Oga::LRU#[]) Mixed wasn't able to be resolved to a constant in this project
[WARN ] (Oga::LRU#[]) Mixed wasn't able to be resolved to a constant in this project
[WARN ] (Oga::LRU#[]=) Mixed wasn't able to be resolved to a constant in this project
[WARN ] (Oga::LRU#[]=) Mixed wasn't able to be resolved to a constant in this project
[OMIT ] (Oga::LRU#[]=) no YARD return type given, using T.untyped
[WARN ] (Oga::LRU#get_or_set) Mixed wasn't able to be resolved to a constant in this project
[WARN ] (Oga::LRU#get_or_set) Mixed wasn't able to be resolved to a constant in this project
[WARN ] (Oga::LRU#key?) Mixed wasn't able to be resolved to a constant in this project
[WARN ] (Oga::LRU#key?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::LRU#clear) no YARD return type given, using T.untyped
[OMIT ] (Oga::LRU#synchronize) no YARD return type given, using T.untyped
[OMIT ] (Oga::LRU#resize) no YARD return type given, using T.untyped
[INFER] (Oga::XML::Node#previous=) inferred type of parameter "value" as Oga::XML::Node using getter's return type
[INFER] (Oga::XML::Node#next=) inferred type of parameter "value" as Oga::XML::Node using getter's return type
[OMIT ] (Oga::XML::Node#node_set=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#children=) "Oga::XML::NodeSet|Array" does not appear to be a type
[OMIT ] (Oga::XML::Node#children=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#root_node) "Oga::XML::Document|Oga::XML::Node" does not appear to be a type
[WARN ] (Oga::XML::Node#replace) "String|Oga::XML::Node" does not appear to be a type
[OMIT ] (Oga::XML::Node#replace) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Node#before) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Node#after) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#html?) "TrueClass|FalseClass" does not appear to be a type
[WARN ] (Oga::XML::Node#xml?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::Node#each_ancestor) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Traversal#each_node) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Text#initialize) no YARD type given for "args", using T.untyped
[OMIT ] (Oga::XML::Text#text=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Text#decode_entities?) "TrueClass|FalseClass" does not appear to be a type
[WARN ] (Oga::XML::Text#inside_literal_html?) "TrueClass|FalseClass" does not appear to be a type
[INFER] (Oga::XML::Node#previous=) inferred type of parameter "value" as Oga::XML::Node using getter's return type
[INFER] (Oga::XML::Node#next=) inferred type of parameter "value" as Oga::XML::Node using getter's return type
[OMIT ] (Oga::XML::Node#node_set=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#children=) "Oga::XML::NodeSet|Array" does not appear to be a type
[OMIT ] (Oga::XML::Node#children=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#root_node) "Oga::XML::Document|Oga::XML::Node" does not appear to be a type
[WARN ] (Oga::XML::Node#replace) "String|Oga::XML::Node" does not appear to be a type
[OMIT ] (Oga::XML::Node#replace) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Node#before) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Node#after) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#html?) "TrueClass|FalseClass" does not appear to be a type
[WARN ] (Oga::XML::Node#xml?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::Node#each_ancestor) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Traversal#each_node) no YARD return type given, using T.untyped
[INFER] (Oga::XML::CharacterNode#text=) inferred type of parameter "value" as String using getter's return type
[INFER] (Oga::XML::Node#previous=) inferred type of parameter "value" as Oga::XML::Node using getter's return type
[INFER] (Oga::XML::Node#next=) inferred type of parameter "value" as Oga::XML::Node using getter's return type
[OMIT ] (Oga::XML::Node#node_set=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#children=) "Oga::XML::NodeSet|Array" does not appear to be a type
[OMIT ] (Oga::XML::Node#children=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#root_node) "Oga::XML::Document|Oga::XML::Node" does not appear to be a type
[WARN ] (Oga::XML::Node#replace) "String|Oga::XML::Node" does not appear to be a type
[OMIT ] (Oga::XML::Node#replace) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Node#before) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Node#after) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#html?) "TrueClass|FalseClass" does not appear to be a type
[WARN ] (Oga::XML::Node#xml?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::Node#each_ancestor) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Traversal#each_node) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Lexer#initialize) "String|IO" does not appear to be a type
[OMIT ] (Oga::XML::Lexer#advance) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Lexer#html?) "TrueClass|FalseClass" does not appear to be a type
[WARN ] (Oga::XML::Lexer#strict?) "TrueClass|FalseClass" does not appear to be a type
[WARN ] (Oga::XML::Lexer#html_script?) "TrueClass|FalseClass" does not appear to be a type
[WARN ] (Oga::XML::Lexer#html_style?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::Lexer#advance_line) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#add_token) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_string_squote) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_string_dquote) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_string_body) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_doctype_start) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_doctype_type) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_doctype_name) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_doctype_end) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_doctype_inline) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_cdata_start) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_cdata_end) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_cdata_body) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_comment_start) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_comment_end) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_comment_body) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_xml_decl_start) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_xml_decl_end) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_proc_ins_start) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_proc_ins_name) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_proc_ins_body) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_proc_ins_end) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_element_name) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#before_html_element_name) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#add_element) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_element_ns) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_element_open_end) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_element_end) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_text) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_attribute_ns) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Lexer#on_attribute) no YARD return type given, using T.untyped
[INFER] (Oga::XML::CharacterNode#text=) inferred type of parameter "value" as String using getter's return type
[INFER] (Oga::XML::Node#previous=) inferred type of parameter "value" as Oga::XML::Node using getter's return type
[INFER] (Oga::XML::Node#next=) inferred type of parameter "value" as Oga::XML::Node using getter's return type
[OMIT ] (Oga::XML::Node#node_set=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#children=) "Oga::XML::NodeSet|Array" does not appear to be a type
[OMIT ] (Oga::XML::Node#children=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#root_node) "Oga::XML::Document|Oga::XML::Node" does not appear to be a type
[WARN ] (Oga::XML::Node#replace) "String|Oga::XML::Node" does not appear to be a type
[OMIT ] (Oga::XML::Node#replace) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Node#before) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Node#after) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#html?) "TrueClass|FalseClass" does not appear to be a type
[WARN ] (Oga::XML::Node#xml?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::Node#each_ancestor) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Traversal#each_node) no YARD return type given, using T.untyped
[INFER] (Oga::XML::Doctype#name=) inferred type of parameter "value" as String using getter's return type
[INFER] (Oga::XML::Doctype#type=) inferred type of parameter "value" as String using getter's return type
[INFER] (Oga::XML::Doctype#public_id=) inferred type of parameter "value" as String using getter's return type
[INFER] (Oga::XML::Doctype#system_id=) inferred type of parameter "value" as String using getter's return type
[INFER] (Oga::XML::Doctype#inline_rules=) inferred type of parameter "value" as String using getter's return type
[INFER] (Oga::XML::Node#previous=) inferred type of parameter "value" as Oga::XML::Node using getter's return type
[INFER] (Oga::XML::Node#next=) inferred type of parameter "value" as Oga::XML::Node using getter's return type
[OMIT ] (Oga::XML::Node#node_set=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#children=) "Oga::XML::NodeSet|Array" does not appear to be a type
[OMIT ] (Oga::XML::Node#children=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#root_node) "Oga::XML::Document|Oga::XML::Node" does not appear to be a type
[WARN ] (Oga::XML::Node#replace) "String|Oga::XML::Node" does not appear to be a type
[OMIT ] (Oga::XML::Node#replace) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Node#before) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Node#after) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#html?) "TrueClass|FalseClass" does not appear to be a type
[WARN ] (Oga::XML::Node#xml?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::Node#each_ancestor) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Traversal#each_node) no YARD return type given, using T.untyped
[INFER] (Oga::XML::Element#name=) inferred type of parameter "value" as String using getter's return type
[INFER] (Oga::XML::Element#attributes=) inferred type of parameter "value" as T::Array[Oga::XML::Attribute] using getter's return type
[INFER] (Oga::XML::Element#namespaces=) inferred type of parameter "value" as Hash using getter's return type
[OMIT ] (Oga::XML::Element#namespace_name=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Element#attribute) "String|Symbol" does not appear to be a type
[OMIT ] (Oga::XML::Element#get) no YARD type given for "name", using T.untyped
[OMIT ] (Oga::XML::Element#get) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Element#add_attribute) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Element#set) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Element#default_namespace?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::Element#inner_text=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Element#register_namespace) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::Element#register_namespace) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Element#self_closing?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::Element#flush_namespaces_cache) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Element#literal_html_name?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::Element#register_namespaces_from_attributes) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Element#link_attributes) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Element#attribute_matches?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::Querying#at_xpath) no YARD type given for "args", using T.untyped
[WARN ] (Oga::XML::Querying#at_xpath) "Oga::XML::Node|Oga::XML::Attribute" does not appear to be a type
[OMIT ] (Oga::XML::Querying#at_css) no YARD type given for "args", using T.untyped
[WARN ] (Oga::XML::Querying#at_css) "Oga::XML::Node|Oga::XML::Attribute" does not appear to be a type
[INFER] (Oga::XML::Node#previous=) inferred type of parameter "value" as Oga::XML::Node using getter's return type
[INFER] (Oga::XML::Node#next=) inferred type of parameter "value" as Oga::XML::Node using getter's return type
[OMIT ] (Oga::XML::Node#node_set=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#children=) "Oga::XML::NodeSet|Array" does not appear to be a type
[OMIT ] (Oga::XML::Node#children=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#root_node) "Oga::XML::Document|Oga::XML::Node" does not appear to be a type
[WARN ] (Oga::XML::Node#replace) "String|Oga::XML::Node" does not appear to be a type
[OMIT ] (Oga::XML::Node#replace) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Node#before) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Node#after) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Node#html?) "TrueClass|FalseClass" does not appear to be a type
[WARN ] (Oga::XML::Node#xml?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::Node#each_ancestor) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Traversal#each_node) no YARD return type given, using T.untyped
[INFER] (Oga::XML::Document#doctype=) inferred type of parameter "value" as Oga::XML::Doctype using getter's return type
[INFER] (Oga::XML::Document#xml_declaration=) inferred type of parameter "value" as Oga::XML::XmlDeclaration using getter's return type
[WARN ] (Oga::XML::Document#children=) "Oga::XML::NodeSet|Array" does not appear to be a type
[OMIT ] (Oga::XML::Document#children=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Document#html?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::Traversal#each_node) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Querying#at_xpath) no YARD type given for "args", using T.untyped
[WARN ] (Oga::XML::Querying#at_xpath) "Oga::XML::Node|Oga::XML::Attribute" does not appear to be a type
[OMIT ] (Oga::XML::Querying#at_css) no YARD type given for "args", using T.untyped
[WARN ] (Oga::XML::Querying#at_css) "Oga::XML::Node|Oga::XML::Attribute" does not appear to be a type
[INFER] (Oga::XML::NodeSet#owner=) inferred type of parameter "value" as Oga::XML::Node using getter's return type
[OMIT ] (Oga::XML::NodeSet#each) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::NodeSet#empty?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::NodeSet#push) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::NodeSet#unshift) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::NodeSet#insert) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::NodeSet#==) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::NodeSet#concat) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::NodeSet#remove) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::NodeSet#delete) no YARD type given for "node", using T.untyped
[OMIT ] (Oga::XML::NodeSet#delete) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::NodeSet#attribute) "String|Symbol" does not appear to be a type
[OMIT ] (Oga::XML::NodeSet#take_ownership) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::NodeSet#remove_ownership) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::NodeSet#exists?) "Oga::XML::Node|Oga::XML::Attribute" does not appear to be a type
[WARN ] (Oga::XML::NodeSet#exists?) "TrueClass|FalseClass" does not appear to be a type
[WARN ] (Oga::XML::NodeSet#mark_existing) "Oga::XML::Node|Oga::XML::Attribute" does not appear to be a type
[OMIT ] (Oga::XML::NodeSet#mark_existing) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::NodeSet#unmark_existing) "Oga::XML::Node|Oga::XML::Attribute" does not appear to be a type
[OMIT ] (Oga::XML::NodeSet#unmark_existing) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Querying#at_xpath) no YARD type given for "args", using T.untyped
[WARN ] (Oga::XML::Querying#at_xpath) "Oga::XML::Node|Oga::XML::Attribute" does not appear to be a type
[OMIT ] (Oga::XML::Querying#at_css) no YARD type given for "args", using T.untyped
[WARN ] (Oga::XML::Querying#at_css) "Oga::XML::Node|Oga::XML::Attribute" does not appear to be a type
[INFER] (Oga::XML::Attribute#name=) inferred type of parameter "value" as String using getter's return type
[INFER] (Oga::XML::Attribute#namespace_name=) inferred type of parameter "value" as String using getter's return type
[INFER] (Oga::XML::Attribute#element=) inferred type of parameter "value" as Oga::XML::Element using getter's return type
[OMIT ] (Oga::XML::Attribute#value=) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Attribute#value) "String|NilClass" does not appear to be a type
[OMIT ] (Oga::XML::Attribute#each_ancestor) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Attribute#html?) "TrueClass|FalseClass" does not appear to be a type
[WARN ] (Oga::XML::Generator#initialize) "Oga::XML::Document|Oga::XML::Node" does not appear to be a type
[OMIT ] (Oga::XML::Generator#on_text) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Generator#on_cdata) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Generator#on_comment) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Generator#on_processing_instruction) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Generator#on_element) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Generator#after_element) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Generator#on_attribute) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Generator#on_doctype) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Generator#on_document) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::Generator#on_xml_declaration) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::Generator#self_closing?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::Generator#html_void_element?) no YARD type given for "element", using T.untyped
[INFER] (Oga::XML::Namespace#name=) inferred type of parameter "value" as String using getter's return type
[INFER] (Oga::XML::Namespace#uri=) inferred type of parameter "value" as String using getter's return type
[WARN ] (Oga::XML::Namespace#==) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::Traversal#each_node) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::SaxParser#initialize) no YARD type given for "args", using T.untyped
[OMIT ] (Oga::XML::SaxParser#on_element) no YARD type given for "namespace", using T.untyped
[OMIT ] (Oga::XML::SaxParser#on_element) no YARD type given for "name", using T.untyped
[OMIT ] (Oga::XML::SaxParser#on_element) no YARD type given for "attrs", using T.untyped
[OMIT ] (Oga::XML::SaxParser#after_element) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::SaxParser#on_attribute) no YARD type given for "name", using T.untyped
[OMIT ] (Oga::XML::SaxParser#on_attribute) no YARD type given for "ns", using T.untyped
[OMIT ] (Oga::XML::SaxParser#on_attribute) no YARD type given for "value", using T.untyped
[OMIT ] (Oga::XML::SaxParser#on_attribute) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::SaxParser#on_text) no YARD return type given, using T.untyped
[WARN ] (Oga::XML::SaxParser#inside_literal_html?) "TrueClass|FalseClass" does not appear to be a type
[OMIT ] (Oga::XML::SaxParser#run_callback) no YARD return type given, using T.untyped
[OMIT ] (Oga::XML::PullParser#initialize) no YARD type given for "args", using T.untyped
[ERROR] undefined method `gsub' for nil:NilClass
         /Users/connorshea/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/commander-4.4.7/lib/commander/user_interaction.rb:359:in `method_missing'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:174:in `block (3 levels) in add_methods'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:173:in `map'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:173:in `block (2 levels) in add_methods'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:157:in `each'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:157:in `map'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:157:in `block in add_methods'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:124:in `each'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:124:in `add_methods'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:245:in `add_namespace'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:248:in `block in add_namespace'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:248:in `each'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:248:in `add_namespace'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:248:in `block in add_namespace'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:248:in `each'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:248:in `add_namespace'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:262:in `block in generate'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:262:in `each'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:262:in `generate'
         /Users/connorshea/Programming/sord/lib/sord/rbi_generator.rb:278:in `run'
         /Users/connorshea/Programming/sord/exe/sord:40:in `block (2 levels) in <top (required)>'
         /Users/connorshea/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/commander-4.4.7/lib/commander/command.rb:182:in `call'
         /Users/connorshea/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/commander-4.4.7/lib/commander/command.rb:153:in `run'
         /Users/connorshea/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/commander-4.4.7/lib/commander/runner.rb:446:in `run_active_command'
         /Users/connorshea/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/commander-4.4.7/lib/commander/runner.rb:71:in `run!'
         /Users/connorshea/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/commander-4.4.7/lib/commander/delegates.rb:15:in `run!'
         /Users/connorshea/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/commander-4.4.7/lib/commander/import.rb:5:in `block in <top (required)>'
oga.rbi generated!
```

After: It actually generates successfully.