### PR TITLE
Add more YARD docs to Sord itself

### DIFF
--- a/lib/sord/logging.rb
+++ b/lib/sord/logging.rb
@@ -45,6 +45,7 @@ module Sord
     # Gets the array of log messages types which should be processed. Any not on
     # this list will be discarded.
     # @return [Array<Symbol>]
+    # @return [void]
     def self.enabled_types
       @@enabled_types
     end
@@ -68,6 +69,7 @@ module Sord
     #  is associated with, if any. This is shown before the log message if it is
     #  specified.
     # @param [Integer] indent_level The level at which to indent the code.
+    # @return [void]
     def self.generic(kind, header, msg, item, indent_level = 0)
       return unless enabled_types.include?(kind)
 
@@ -87,6 +89,7 @@ module Sord
     #  is associated with, if any. This is shown before the log message if it is
     #  specified.
     # @param [Integer] indent_level The level at which to indent the code.
+    # @return [void]
     def self.warn(msg, item = nil, indent_level = 0)
       generic(:warn, '[WARN ]'.yellow, msg, item, indent_level)
     end
@@ -98,6 +101,7 @@ module Sord
     #  is associated with, if any. This is shown before the log message if it is
     #  specified.
     # @param [Integer] indent_level The level at which to indent the code.
+    # @return [void]
     def self.info(msg, item = nil, indent_level = 0)
       generic(:info, '[INFO ]', msg, item, indent_level)
     end
@@ -110,6 +114,7 @@ module Sord
     #  is associated with, if any. This is shown before the log message if it is
     #  specified.
     # @param [Integer] indent_level The level at which to indent the code.
+    # @return [void]
     def self.duck(msg, item = nil, indent_level = 0)
       generic(:duck, '[DUCK ]'.cyan, msg, item, indent_level)
     end
@@ -121,6 +126,7 @@ module Sord
     #  is associated with, if any. This is shown before the log message if it is
     #  specified.
     # @param [Integer] indent_level The level at which to indent the code.
+    # @return [void]
     def self.error(msg, item = nil, indent_level = 0)
       generic(:error, '[ERROR]'.red, msg, item, indent_level)
     end
@@ -133,6 +139,7 @@ module Sord
     #  is associated with, if any. This is shown before the log message if it is
     #  specified.
     # @param [Integer] indent_level The level at which to indent the code.
+    # @return [void]
     def self.infer(msg, item = nil, indent_level = 0)
       generic(:infer, '[INFER]'.light_blue, msg, item, indent_level)
     end
@@ -145,16 +152,19 @@ module Sord
     #  is associated with, if any. This is shown before the log message if it is
     #  specified.
     # @param [Integer] indent_level The level at which to indent the code.
+    # @return [void]
     def self.omit(msg, item = nil, indent_level = 0)
       generic(:omit, '[OMIT ]'.magenta, msg, item, indent_level)
     end
 
     # Print a done message. This should be used when a process completes
     # successfully.
+    # @param [String] msg The log message to write.
     # @param [YARD::CodeObjects::Base] item The CodeObject which this log 
     #  is associated with, if any. This is shown before the log message if it is
     #  specified.
     # @param [Integer] indent_level The level at which to indent the code.
+    # @return [void]
     def self.done(msg, item = nil, indent_level = 0)
       generic(:done, '[DONE ]'.green, msg, item)
     end
@@ -166,6 +176,7 @@ module Sord
     #  is associated with, if any. This is shown before the log message if it is
     #  specified.
     # @param [Integer] indent_level The level at which to indent the code.
+    # @return [void]
     def self.invoke_hooks(kind, msg, item, indent_level = 0)
       @@hooks.each do |hook|
         hook.(kind, msg, item, indent_level) rescue nil
@@ -180,6 +191,7 @@ module Sord
     #  specified.
     # @yieldparam [Integer] indent_level The level at which to indent the code.
     # @yieldreturn [void]
+    # @return [void]
     def self.add_hook(&blk)
       @@hooks << blk
     end

--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -31,7 +31,7 @@ module Sord
     # @option options [Integer] break_params
     # @option options [Boolean] replace_errors_with_untyped
     # @option options [Boolean] comments
-    # @return [RbiGenerator]
+    # @return [void]
     def initialize(options)
       @rbi_contents = ['# typed: strong']
       @namespace_count = 0
@@ -231,6 +231,7 @@ module Sord
     # and children to the RBI file.
     # @param [YARD::CodeObjects::NamespaceObject] item
     # @param [Integer] indent_level
+    # @return [void]
     def add_namespace(item, indent_level = 0)
       count_namespace
       add_blank

--- a/lib/sord/resolver.rb
+++ b/lib/sord/resolver.rb
@@ -2,6 +2,7 @@ require 'stringio'
 
 module Sord
   module Resolver
+    # @return [void]
     def self.prepare
       # Construct a hash of class names to full paths
       @@names_to_paths ||= YARD::Registry.all(:class)
@@ -13,20 +14,26 @@ module Sord
         end
     end
 
+    # @return [void]
     def self.clear
       @@names_to_paths = nil
     end
 
+    # @param [String] name
+    # @return [Array<String>]
     def self.paths_for(name)
       prepare
       (@@names_to_paths[name.split('::').last] || [])
         .select { |x| x.end_with?(name) }
     end
 
+    # @param [String] name
+    # @return [String, nil]
     def self.path_for(name)
       paths_for(name).one? ? paths_for(name).first : nil
     end
 
+    # @return [Array<String>]
     def self.builtin_classes
       # This prints some deprecation warnings, so suppress them
       prev_stderr = $stderr
@@ -39,6 +46,9 @@ module Sord
       $stderr = prev_stderr
     end
 
+    # @param [String] name
+    # @param [Object] item
+    # @return [Boolean]
     def self.resolvable?(name, item)
       name_parts = name.split('::')
 

--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -97,6 +97,7 @@ module Sord
     # @param [Integer] indent_level 
     # @param [Boolean] replace_errors_with_untyped If true, T.untyped is used
     #   instead of SORD_ERROR_ constants for unknown types.
+    # @return [String]
     def self.yard_to_sorbet(yard, item = nil, indent_level = 0, replace_errors_with_untyped = false)
       case yard
       when nil # Type not specified

--- a/rbi/sord.rbi
+++ b/rbi/sord.rbi
@@ -20,7 +20,6 @@ module Sord
     def self.valid_types?(value); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    # sord omit - no YARD return type given, using T.untyped
     sig do
       params(
         kind: Symbol,
@@ -28,61 +27,51 @@ module Sord
         msg: String,
         item: YARD::CodeObjects::Base,
         indent_level: Integer
-      ).returns(T.untyped)
+      ).void
     end
     def self.generic(kind, header, msg, item, indent_level = 0); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    # sord omit - no YARD return type given, using T.untyped
-    sig { params(msg: String, item: YARD::CodeObjects::Base, indent_level: Integer).returns(T.untyped) }
+    sig { params(msg: String, item: YARD::CodeObjects::Base, indent_level: Integer).void }
     def self.warn(msg, item = nil, indent_level = 0); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    # sord omit - no YARD return type given, using T.untyped
-    sig { params(msg: String, item: YARD::CodeObjects::Base, indent_level: Integer).returns(T.untyped) }
+    sig { params(msg: String, item: YARD::CodeObjects::Base, indent_level: Integer).void }
     def self.info(msg, item = nil, indent_level = 0); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    # sord omit - no YARD return type given, using T.untyped
-    sig { params(msg: String, item: YARD::CodeObjects::Base, indent_level: Integer).returns(T.untyped) }
+    sig { params(msg: String, item: YARD::CodeObjects::Base, indent_level: Integer).void }
     def self.duck(msg, item = nil, indent_level = 0); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    # sord omit - no YARD return type given, using T.untyped
-    sig { params(msg: String, item: YARD::CodeObjects::Base, indent_level: Integer).returns(T.untyped) }
+    sig { params(msg: String, item: YARD::CodeObjects::Base, indent_level: Integer).void }
     def self.error(msg, item = nil, indent_level = 0); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    # sord omit - no YARD return type given, using T.untyped
-    sig { params(msg: String, item: YARD::CodeObjects::Base, indent_level: Integer).returns(T.untyped) }
+    sig { params(msg: String, item: YARD::CodeObjects::Base, indent_level: Integer).void }
     def self.infer(msg, item = nil, indent_level = 0); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    # sord omit - no YARD return type given, using T.untyped
-    sig { params(msg: String, item: YARD::CodeObjects::Base, indent_level: Integer).returns(T.untyped) }
+    sig { params(msg: String, item: YARD::CodeObjects::Base, indent_level: Integer).void }
     def self.omit(msg, item = nil, indent_level = 0); end
 
-    # sord omit - no YARD type given for "msg", using T.untyped
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    # sord omit - no YARD return type given, using T.untyped
-    sig { params(msg: T.untyped, item: YARD::CodeObjects::Base, indent_level: Integer).returns(T.untyped) }
+    sig { params(msg: String, item: YARD::CodeObjects::Base, indent_level: Integer).void }
     def self.done(msg, item = nil, indent_level = 0); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    # sord omit - no YARD return type given, using T.untyped
     sig do
       params(
         kind: Symbol,
         msg: String,
         item: YARD::CodeObjects::Base,
         indent_level: Integer
-      ).returns(T.untyped)
+      ).void
     end
     def self.invoke_hooks(kind, msg, item, indent_level = 0); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    # sord omit - no YARD return type given, using T.untyped
-    sig { params(blk: T.proc.params(kind: Symbol, msg: String, item: YARD::CodeObjects::Base, indent_level: Integer).returns(T.untyped)).returns(T.untyped) }
+    sig { params(blk: T.proc.params(kind: Symbol, msg: String, item: YARD::CodeObjects::Base, indent_level: Integer).returns(T.untyped)).void }
     def self.add_hook(&blk); end
   end
 
@@ -124,7 +113,7 @@ module Sord
     sig { params(value: T::Boolean).returns(T::Boolean) }
     def next_item_is_first_in_namespace=(value); end
 
-    sig { params(options: Hash).returns(RbiGenerator) }
+    sig { params(options: Hash).void }
     def initialize(options); end
 
     sig { void }
@@ -148,8 +137,7 @@ module Sord
     def add_methods(item, indent_level); end
 
     # sord warn - YARD::CodeObjects::NamespaceObject wasn't able to be resolved to a constant in this project
-    # sord omit - no YARD return type given, using T.untyped
-    sig { params(item: YARD::CodeObjects::NamespaceObject, indent_level: Integer).returns(T.untyped) }
+    sig { params(item: YARD::CodeObjects::NamespaceObject, indent_level: Integer).void }
     def add_namespace(item, indent_level = 0); end
 
     sig { returns(String) }

--- a/rbi/sord.rbi
+++ b/rbi/sord.rbi
@@ -10,6 +10,15 @@ module Sord
     sig { params(value: T::Boolean).void }
     def self.silent=(value); end
 
+    sig { params(value: T::Array[Symbol]).void }
+    def self.enabled_types=(value); end
+
+    sig { returns(T::Array[Symbol]) }
+    def self.enabled_types(); end
+
+    sig { params(value: T::Array[Symbol]).void }
+    def self.valid_types?(value); end
+
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
     # sord omit - no YARD return type given, using T.untyped
     sig do
@@ -78,31 +87,22 @@ module Sord
   end
 
   module Resolver
-    # sord omit - no YARD return type given, using T.untyped
-    sig { returns(T.untyped) }
+    sig { void }
     def self.prepare(); end
 
-    # sord omit - no YARD return type given, using T.untyped
-    sig { returns(T.untyped) }
+    sig { void }
     def self.clear(); end
 
-    # sord omit - no YARD type given for "name", using T.untyped
-    # sord omit - no YARD return type given, using T.untyped
-    sig { params(name: T.untyped).returns(T.untyped) }
+    sig { params(name: String).returns(T::Array[String]) }
     def self.paths_for(name); end
 
-    # sord omit - no YARD type given for "name", using T.untyped
-    # sord omit - no YARD return type given, using T.untyped
-    sig { params(name: T.untyped).returns(T.untyped) }
+    sig { params(name: String).returns(T.nilable(String)) }
     def self.path_for(name); end
 
-    # sord omit - no YARD return type given, using T.untyped
-    sig { returns(T.untyped) }
+    sig { returns(T::Array[String]) }
     def self.builtin_classes(); end
 
-    # sord omit - no YARD type given for "name", using T.untyped
-    # sord omit - no YARD type given for "item", using T.untyped
-    sig { params(name: T.untyped, item: T.untyped).returns(T::Boolean) }
+    sig { params(name: String, item: Object).returns(T::Boolean) }
     def self.resolvable?(name, item); end
   end
 
@@ -164,14 +164,13 @@ module Sord
     def self.split_type_parameters(params); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    # sord omit - no YARD return type given, using T.untyped
     sig do
       params(
         yard: T.any(T::Boolean, Array, String),
         item: YARD::CodeObjects::Base,
         indent_level: Integer,
         replace_errors_with_untyped: T::Boolean
-      ).returns(T.untyped)
+      ).returns(String)
     end
     def self.yard_to_sorbet(yard, item = nil, indent_level = 0, replace_errors_with_untyped = false); end
   end

--- a/sorbet/rbi/gems/sorbet-runtime.rbi
+++ b/sorbet/rbi/gems/sorbet-runtime.rbi
@@ -7,11 +7,13 @@
 #
 #   https://github.com/sorbet/sorbet-typed/new/master?filename=lib/sorbet-runtime/all/sorbet-runtime.rbi
 #
-# sorbet-runtime-0.4.4295
+# sorbet-runtime-0.4.4358
 module T::Configuration
   def self.call_validation_error_handler(signature, opts); end
   def self.call_validation_error_handler=(value); end
   def self.call_validation_error_handler_default(signature, opts); end
+  def self.default_checked_level=(default_checked_level); end
+  def self.enable_checking_for_sigs_marked_checked_tests; end
   def self.hard_assert_handler(str, extra); end
   def self.hard_assert_handler=(value); end
   def self.hard_assert_handler_default(str, _); end
@@ -70,7 +72,6 @@ class T::Private::DeclState
   def self.current=(other); end
 end
 module T::Utils
-  def self.DANGER_enable_checking_in_tests; end
   def self.arity(method); end
   def self.coerce(val); end
   def self.methods_excluding_object(mod); end
@@ -103,6 +104,8 @@ end
 module T::Private::RuntimeLevels
   def self._toggle_checking_tests(checked); end
   def self.check_tests?; end
+  def self.default_checked_level; end
+  def self.default_checked_level=(default_checked_level); end
   def self.enable_checking_in_tests; end
 end
 module T::Private::Methods
@@ -388,11 +391,6 @@ class T::Private::Methods::Signature
   def self.new_untyped(method:, mode: nil, parameters: nil); end
   def soft_notify; end
 end
-module T::Utils::Props
-  def self.merge_serialized_optional_rule(prop_rules); end
-  def self.optional_prop?(prop_rules); end
-  def self.required_prop?(prop_rules); end
-end
 module T::Utils::Nilable
   def self.get_type_info(prop_type); end
   def self.get_underlying_type(prop_type); end
@@ -459,7 +457,7 @@ class T::Props::Decorator
   def array_subdoc_type(*args, &blk); end
   def check_prop_type(*args, &blk); end
   def convert_type_to_class(*args, &blk); end
-  def decorated_class(*args, &blk); end
+  def decorated_class; end
   def define_foreign_method(*args, &blk); end
   def define_getter_and_setter(*args, &blk); end
   def foreign_prop_get(*args, &blk); end
@@ -479,7 +477,7 @@ class T::Props::Decorator
   def prop_rules(*args, &blk); end
   def prop_set(*args, &blk); end
   def prop_validate_definition!(*args, &blk); end
-  def props(*args, &blk); end
+  def props; end
   def self.method_added(name); end
   def self.singleton_method_added(name); end
   def set(*args, &blk); end
@@ -514,8 +512,11 @@ module T::Props::Plugin::ClassMethods
 end
 module T::Props::Utils
   def self.deep_clone_object(what, freeze: nil); end
+  def self.merge_serialized_optional_rule(prop_rules); end
   def self.need_nil_read_check?(prop_rules); end
   def self.need_nil_write_check?(prop_rules); end
+  def self.optional_prop?(prop_rules); end
+  def self.required_prop?(prop_rules); end
 end
 module T::Props::Optional
   extend T::Props::ClassMethods
@@ -524,8 +525,10 @@ module T::Props::Optional
 end
 module T::Props::Optional::DecoratorMethods
   def add_prop_definition(prop, rules); end
+  def compute_derived_rules(rules); end
   def get_default(rules, instance_class); end
   def has_default?(rules); end
+  def mutate_prop_backdoor!(prop, key, value); end
   def prop_optional?(prop); end
   def prop_validate_definition!(name, cls, rules, type); end
   def valid_props; end

--- a/sorbet/rbi/hidden-definitions/errors.txt
+++ b/sorbet/rbi/hidden-definitions/errors.txt
@@ -28,11 +28,7 @@
 # wrong constant name <RESERVED_114>
 # wrong constant name <RESERVED_115>
 # wrong constant name <RESERVED_116>
-# wrong constant name <RESERVED_117>
-# wrong constant name <RESERVED_118>
-# wrong constant name <RESERVED_119>
 # wrong constant name <RESERVED_11>
-# wrong constant name <RESERVED_120>
 # wrong constant name <RESERVED_12>
 # wrong constant name <RESERVED_13>
 # wrong constant name <RESERVED_14>
@@ -171,9 +167,11 @@
 # wrong constant name bsearch_index
 # wrong constant name collect!
 # wrong constant name concat$1
+# wrong constant name difference
 # wrong constant name dig
 # wrong constant name fetch$2
 # wrong constant name fill$2
+# wrong constant name filter!
 # wrong constant name flatten$1
 # wrong constant name flatten!
 # wrong constant name index$2
@@ -197,133 +195,38 @@
 # wrong constant name slice$2
 # wrong constant name slice!$2
 # wrong constant name to_h
+# wrong constant name union
 # wrong constant name try_convert
 # uninitialized constant Base64
 # uninitialized constant Base64
 # wrong constant name <Class:BasicObject>
-# uninitialized constant BasicSocket::APPEND
-# Did you mean?  BasicSocket::APPEND
-# uninitialized constant BasicSocket::BINARY
-# Did you mean?  BasicSocket::BINARY
-# uninitialized constant BasicSocket::CREAT
-# Did you mean?  BasicSocket::CREAT
-# uninitialized constant BasicSocket::DIRECT
-# Did you mean?  BasicSocket::DIRECT
-# uninitialized constant BasicSocket::DSYNC
-# Did you mean?  BasicSocket::RSYNC
-#                BasicSocket::DSYNC
-#                BasicSocket::SYNC
-# uninitialized constant BasicSocket::EXCL
-# Did you mean?  BasicSocket::EXCL
-# uninitialized constant BasicSocket::FNM_CASEFOLD
-# Did you mean?  BasicSocket::FNM_CASEFOLD
-# uninitialized constant BasicSocket::FNM_DOTMATCH
-# Did you mean?  BasicSocket::FNM_DOTMATCH
-# uninitialized constant BasicSocket::FNM_EXTGLOB
-# Did you mean?  BasicSocket::FNM_EXTGLOB
-# uninitialized constant BasicSocket::FNM_NOESCAPE
-# Did you mean?  BasicSocket::FNM_NOESCAPE
-# uninitialized constant BasicSocket::FNM_PATHNAME
-# Did you mean?  BasicSocket::FNM_PATHNAME
-# uninitialized constant BasicSocket::FNM_SHORTNAME
-# Did you mean?  BasicSocket::FNM_SHORTNAME
-# uninitialized constant BasicSocket::FNM_SYSCASE
-# Did you mean?  BasicSocket::FNM_SYSCASE
-# uninitialized constant BasicSocket::LOCK_EX
-# Did you mean?  BasicSocket::LOCK_NB
-#                BasicSocket::LOCK_UN
-#                BasicSocket::LOCK_EX
-#                BasicSocket::LOCK_SH
-# uninitialized constant BasicSocket::LOCK_NB
-# Did you mean?  BasicSocket::LOCK_NB
-#                BasicSocket::LOCK_UN
-#                BasicSocket::LOCK_EX
-#                BasicSocket::LOCK_SH
-# uninitialized constant BasicSocket::LOCK_SH
-# Did you mean?  BasicSocket::LOCK_NB
-#                BasicSocket::LOCK_UN
-#                BasicSocket::LOCK_EX
-#                BasicSocket::LOCK_SH
-# uninitialized constant BasicSocket::LOCK_UN
-# Did you mean?  BasicSocket::LOCK_NB
-#                BasicSocket::LOCK_UN
-#                BasicSocket::LOCK_EX
-#                BasicSocket::LOCK_SH
-# uninitialized constant BasicSocket::NOATIME
-# Did you mean?  BasicSocket::NOATIME
-# uninitialized constant BasicSocket::NOCTTY
-# Did you mean?  BasicSocket::NOCTTY
-# uninitialized constant BasicSocket::NOFOLLOW
-# Did you mean?  BasicSocket::NOFOLLOW
-# uninitialized constant BasicSocket::NONBLOCK
-# Did you mean?  BasicSocket::NONBLOCK
-# uninitialized constant BasicSocket::NULL
-# Did you mean?  BasicSocket::NULL
-# uninitialized constant BasicSocket::RDONLY
-# Did you mean?  BasicSocket::WRONLY
-#                BasicSocket::RDONLY
-# uninitialized constant BasicSocket::RDWR
-# Did you mean?  BasicSocket::RDWR
-# uninitialized constant BasicSocket::RSYNC
-# Did you mean?  BasicSocket::RSYNC
-#                BasicSocket::DSYNC
-#                BasicSocket::SYNC
-# uninitialized constant BasicSocket::SEEK_CUR
-# Did you mean?  BasicSocket::SEEK_CUR
-# uninitialized constant BasicSocket::SEEK_DATA
-# Did you mean?  BasicSocket::SEEK_SET
-#                BasicSocket::SEEK_DATA
-# uninitialized constant BasicSocket::SEEK_END
-# Did you mean?  BasicSocket::SEEK_END
-# uninitialized constant BasicSocket::SEEK_HOLE
-# Did you mean?  BasicSocket::SEEK_HOLE
-# uninitialized constant BasicSocket::SEEK_SET
-# Did you mean?  BasicSocket::SEEK_SET
-# uninitialized constant BasicSocket::SHARE_DELETE
-# Did you mean?  BasicSocket::SHARE_DELETE
-# uninitialized constant BasicSocket::SYNC
-# Did you mean?  BasicSocket::RSYNC
-#                BasicSocket::DSYNC
-#                BasicSocket::SYNC
-# uninitialized constant BasicSocket::TMPFILE
-# Did you mean?  Tempfile
-#                BasicSocket::TMPFILE
-# uninitialized constant BasicSocket::TRUNC
-# Did you mean?  BasicSocket::TRUNC
-#                TRUE
-# uninitialized constant BasicSocket::WRONLY
-# Did you mean?  BasicSocket::WRONLY
-#                BasicSocket::RDONLY
-# wrong constant name read_nonblock
 # uninitialized constant Benchmark
 # uninitialized constant Benchmark
 # undefined method `_dump$1' for class `BigDecimal'
 # undefined method `div$2' for class `BigDecimal'
-# undefined method `initialize$1' for class `BigDecimal'
-# Did you mean?  initialize
 # undefined method `power$2' for class `BigDecimal'
 # undefined method `to_s$1' for class `BigDecimal'
 # Did you mean?  to_s
 # wrong constant name _dump$1
 # wrong constant name clone
 # wrong constant name div$2
-# wrong constant name initialize$1
 # wrong constant name power$2
 # wrong constant name to_s$1
 # wrong constant name _load
 # wrong constant name double_fig
 # wrong constant name limit
 # wrong constant name mode
+# wrong constant name new
 # wrong constant name save_exception_mode
 # wrong constant name save_limit
 # wrong constant name save_rounding_mode
-# wrong constant name ver
 # wrong constant name clone
 # wrong constant name irb
 # wrong constant name local_variable_defined?
 # wrong constant name local_variable_get
 # wrong constant name local_variable_set
 # wrong constant name receiver
+# wrong constant name source_location
 # wrong constant name jruby_27?
 # wrong constant name maglev_27?
 # wrong constant name mingw_27?
@@ -421,22 +324,15 @@
 # wrong constant name redirect_limit
 # wrong constant name redirect_limit=
 # uninitialized constant Bundler::GemHelper::DEFAULT
-# Did you mean?  Bundler::GemHelper::DEFAULT
 # uninitialized constant Bundler::GemHelper::LN_SUPPORTED
-# Did you mean?  Bundler::GemHelper::LN_SUPPORTED
 # uninitialized constant Bundler::GemHelper::LOW_METHODS
 # Did you mean?  Bundler::GemHelper::LowMethods
-#                Bundler::GemHelper::LOW_METHODS
 # uninitialized constant Bundler::GemHelper::METHODS
 # Did you mean?  Method
-#                Bundler::GemHelper::METHODS
 # uninitialized constant Bundler::GemHelper::OPT_TABLE
-# Did you mean?  Bundler::GemHelper::OPT_TABLE
 # uninitialized constant Bundler::GemHelper::RUBY
-# Did you mean?  Bundler::GemHelper::RUBY
 # uninitialized constant Bundler::GemHelper::VERSION
-# Did you mean?  Bundler::GemHelper::VERSION
-#                Bundler::VERSION
+# Did you mean?  Bundler::VERSION
 # wrong constant name allowed_push_host
 # wrong constant name already_tagged?
 # wrong constant name base
@@ -468,7 +364,6 @@
 # wrong constant name instance
 # wrong constant name instance=
 # uninitialized constant Bundler::GemRemoteFetcher::BASE64_URI_TRANSLATE
-# Did you mean?  Bundler::GemRemoteFetcher::BASE64_URI_TRANSLATE
 # wrong constant name <static-init>
 # wrong constant name initialize
 # wrong constant name level
@@ -512,12 +407,6 @@
 # wrong constant name ambiguous_gems
 # wrong constant name ambiguous_gems=
 # wrong constant name install
-# wrong constant name definition
-# wrong constant name generate!
-# wrong constant name initialize
-# wrong constant name out
-# wrong constant name <static-init>
-# wrong constant name generate
 # wrong constant name ==
 # wrong constant name app_cache_dirname
 # wrong constant name app_cache_path
@@ -553,9 +442,7 @@
 # wrong constant name <static-init>
 # wrong constant name <Class:PluginGemfileError>
 # uninitialized constant Bundler::Plugin::DSL::VALID_KEYS
-# Did you mean?  Bundler::Plugin::DSL::VALID_KEYS
 # uninitialized constant Bundler::Plugin::DSL::VALID_PLATFORMS
-# Did you mean?  Bundler::Plugin::DSL::VALID_PLATFORMS
 # wrong constant name _gem
 # wrong constant name inferred_plugins
 # wrong constant name plugin
@@ -587,15 +474,12 @@
 # wrong constant name install
 # wrong constant name install_definition
 # uninitialized constant Bundler::Plugin::Installer::Git::DEFAULT_GLOB
-# Did you mean?  Bundler::Plugin::Installer::Git::DEFAULT_GLOB
 # wrong constant name generate_bin
 # wrong constant name <static-init>
 # uninitialized constant Bundler::Plugin::Installer::Rubygems::API_REQUEST_LIMIT
 # Did you mean?  Bundler::Plugin::Installer::Rubygems::API_REQUEST_SIZE
-#                Bundler::Plugin::Installer::Rubygems::API_REQUEST_LIMIT
 # uninitialized constant Bundler::Plugin::Installer::Rubygems::API_REQUEST_SIZE
-# Did you mean?  Bundler::Plugin::Installer::Rubygems::API_REQUEST_SIZE
-#                Bundler::Plugin::Installer::Rubygems::API_REQUEST_LIMIT
+# Did you mean?  Bundler::Plugin::Installer::Rubygems::API_REQUEST_LIMIT
 # wrong constant name <static-init>
 # wrong constant name <static-init>
 # wrong constant name <static-init>
@@ -615,7 +499,6 @@
 # wrong constant name default_attempts
 # wrong constant name default_retries
 # uninitialized constant Bundler::RubyGemsGemInstaller::ENV_PATHS
-# Did you mean?  Bundler::RubyGemsGemInstaller::ENV_PATHS
 # wrong constant name <static-init>
 # wrong constant name ==
 # wrong constant name fallback_timeout
@@ -728,8 +611,16 @@
 # wrong constant name rectangular
 # uninitialized constant Configatron
 # uninitialized constant Configatron
-# uninitialized constant Coverage
-# uninitialized constant Coverage
+# undefined singleton method `result$1' for `Coverage'
+# undefined singleton method `start$1' for `Coverage'
+# wrong constant name line_stub
+# wrong constant name peek_result
+# wrong constant name result$1
+# wrong constant name running?
+# wrong constant name start$1
+# wrong constant name initialize
+# undefined singleton method `_parse$1' for `Date'
+# wrong constant name _parse$1
 # wrong constant name !=
 # wrong constant name ==
 # wrong constant name __getobj__
@@ -754,10 +645,6 @@
 # wrong constant name original_message
 # wrong constant name spell_checker
 # wrong constant name to_s
-# wrong constant name +
-# wrong constant name <<
-# uninitialized constant DidYouMean::DeprecatedIgnoredCallers::Elem
-# wrong constant name <static-init>
 # uninitialized constant DidYouMean::Formatter
 # uninitialized constant DidYouMean::Formatter
 # wrong constant name distance
@@ -789,6 +676,11 @@
 # wrong constant name name
 # wrong constant name formatter
 # wrong constant name formatter=
+# undefined method `initialize$1' for class `Dir'
+# Did you mean?  initialize
+# wrong constant name children
+# wrong constant name each_child
+# wrong constant name initialize$1
 # undefined singleton method `[]$2' for `Dir'
 # undefined singleton method `chdir$2' for `Dir'
 # undefined singleton method `entries$1' for `Dir'
@@ -812,8 +704,11 @@
 # wrong constant name mktmpdir$2
 # wrong constant name open$2
 # wrong constant name tmpdir
+# undefined method `initialize$1' for class `ERB'
+# Did you mean?  initialize
 # wrong constant name def_method
 # wrong constant name def_module
+# wrong constant name initialize$1
 # wrong constant name result_with_hash
 # wrong constant name _dump
 # wrong constant name convert
@@ -868,6 +763,7 @@
 # undefined method `to_h$1' for module `Enumerable'
 # wrong constant name all?$2
 # wrong constant name any?$2
+# wrong constant name chain
 # wrong constant name chunk
 # wrong constant name chunk_while
 # wrong constant name count$2
@@ -875,8 +771,8 @@
 # wrong constant name detect$2
 # wrong constant name each_entry
 # wrong constant name each_with_index$2
-# wrong constant name each_with_object
 # wrong constant name entries$1
+# wrong constant name filter
 # wrong constant name find$2
 # wrong constant name find_index$2
 # wrong constant name first$2
@@ -900,14 +796,142 @@
 # wrong constant name to_set
 # wrong constant name uniq
 # wrong constant name zip
+# undefined method `each$2' for class `Enumerator'
+# undefined method `initialize$1' for class `Enumerator'
+# Did you mean?  initialize
+# undefined method `with_index$2' for class `Enumerator'
+# wrong constant name +
+# wrong constant name <Class:ArithmeticSequence>
+# wrong constant name <Class:Chain>
+# wrong constant name each$2
+# wrong constant name each_with_index
+# wrong constant name initialize$1
+# wrong constant name with_index$2
+# uninitialized constant Enumerator::ArithmeticSequence::Elem
+# wrong constant name begin
+# wrong constant name each
+# wrong constant name end
+# wrong constant name exclude_end?
+# wrong constant name last
+# wrong constant name step
+# wrong constant name <static-init>
+# uninitialized constant Enumerator::Chain::Elem
+# wrong constant name <static-init>
 # wrong constant name each
 # wrong constant name initialize
 # wrong constant name chunk
 # wrong constant name chunk_while
 # wrong constant name force
 # wrong constant name slice_when
+# wrong constant name EADV$1
+# wrong constant name EADV$1
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name EBADE$1
+# wrong constant name EBADE$1
+# wrong constant name <static-init>
+# wrong constant name EBADFD$1
+# wrong constant name EBADFD$1
+# wrong constant name <static-init>
+# wrong constant name EBADR$1
+# wrong constant name EBADR$1
+# wrong constant name <static-init>
+# wrong constant name EBADRQC$1
+# wrong constant name EBADRQC$1
+# wrong constant name EBADSLT$1
+# wrong constant name EBADSLT$1
+# wrong constant name EBFONT$1
+# wrong constant name EBFONT$1
+# wrong constant name ECHRNG$1
+# wrong constant name ECHRNG$1
+# wrong constant name ECOMM$1
+# wrong constant name ECOMM$1
+# wrong constant name <static-init>
+# wrong constant name EDOTDOT$1
+# wrong constant name EDOTDOT$1
+# wrong constant name <static-init>
+# wrong constant name EHWPOISON$1
+# wrong constant name EHWPOISON$1
+# wrong constant name EISNAM$1
+# wrong constant name EISNAM$1
+# wrong constant name EKEYEXPIRED$1
+# wrong constant name EKEYEXPIRED$1
+# wrong constant name EKEYREJECTED$1
+# wrong constant name EKEYREJECTED$1
+# wrong constant name EKEYREVOKED$1
+# wrong constant name EKEYREVOKED$1
+# wrong constant name EL2HLT$1
+# wrong constant name EL2HLT$1
+# wrong constant name EL2NSYNC$1
+# wrong constant name EL2NSYNC$1
+# wrong constant name EL3HLT$1
+# wrong constant name EL3HLT$1
+# wrong constant name EL3RST$1
+# wrong constant name EL3RST$1
+# wrong constant name <static-init>
+# wrong constant name ELIBACC$1
+# wrong constant name ELIBACC$1
+# wrong constant name ELIBBAD$1
+# wrong constant name ELIBBAD$1
+# wrong constant name ELIBEXEC$1
+# wrong constant name ELIBEXEC$1
+# wrong constant name ELIBMAX$1
+# wrong constant name ELIBMAX$1
+# wrong constant name ELIBSCN$1
+# wrong constant name ELIBSCN$1
+# wrong constant name ELNRNG$1
+# wrong constant name ELNRNG$1
+# wrong constant name EMEDIUMTYPE$1
+# wrong constant name EMEDIUMTYPE$1
+# wrong constant name ENAVAIL$1
+# wrong constant name ENAVAIL$1
+# wrong constant name <static-init>
+# wrong constant name ENOANO$1
+# wrong constant name ENOANO$1
+# wrong constant name <static-init>
+# wrong constant name ENOCSI$1
+# wrong constant name ENOCSI$1
+# wrong constant name ENOKEY$1
+# wrong constant name ENOKEY$1
+# wrong constant name ENOMEDIUM$1
+# wrong constant name ENOMEDIUM$1
+# wrong constant name ENONET$1
+# wrong constant name ENONET$1
+# wrong constant name ENOPKG$1
+# wrong constant name ENOPKG$1
+# wrong constant name <static-init>
+# wrong constant name ENOTNAM$1
+# wrong constant name ENOTNAM$1
+# wrong constant name <static-init>
+# wrong constant name ENOTUNIQ$1
+# wrong constant name ENOTUNIQ$1
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name EREMCHG$1
+# wrong constant name EREMCHG$1
+# wrong constant name EREMOTEIO$1
+# wrong constant name EREMOTEIO$1
+# wrong constant name ERESTART$1
+# wrong constant name ERESTART$1
+# wrong constant name ERFKILL$1
+# wrong constant name ERFKILL$1
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name ESRMNT$1
+# wrong constant name ESRMNT$1
+# wrong constant name ESTRPIPE$1
+# wrong constant name ESTRPIPE$1
+# wrong constant name EUCLEAN$1
+# wrong constant name EUCLEAN$1
+# wrong constant name EUNATCH$1
+# wrong constant name EUNATCH$1
 # wrong constant name EWOULDBLOCK$1
 # wrong constant name EWOULDBLOCK$1
+# wrong constant name EXFULL$1
+# wrong constant name EXFULL$1
 # wrong constant name gid
 # wrong constant name gid=
 # wrong constant name mem
@@ -920,8 +944,12 @@
 # wrong constant name []
 # wrong constant name each
 # wrong constant name members
+# wrong constant name change
+# wrong constant name change=
 # wrong constant name dir
 # wrong constant name dir=
+# wrong constant name expire
+# wrong constant name expire=
 # wrong constant name gecos
 # wrong constant name gecos=
 # wrong constant name gid
@@ -932,6 +960,8 @@
 # wrong constant name passwd=
 # wrong constant name shell
 # wrong constant name shell=
+# wrong constant name uclass
+# wrong constant name uclass=
 # wrong constant name uid
 # wrong constant name uid=
 # uninitialized constant Etc::Passwd::Elem
@@ -972,7 +1002,6 @@
 # wrong constant name size?
 # undefined singleton method `absolute_path$1' for `File'
 # undefined singleton method `basename$1' for `File'
-# undefined singleton method `birthtime$1' for `File'
 # undefined singleton method `chmod$1' for `File'
 # undefined singleton method `chown$1' for `File'
 # undefined singleton method `expand_path$1' for `File'
@@ -986,7 +1015,6 @@
 # undefined singleton method `utime$1' for `File'
 # wrong constant name absolute_path$1
 # wrong constant name basename$1
-# wrong constant name birthtime$1
 # wrong constant name chmod$1
 # wrong constant name chown$1
 # wrong constant name exists?
@@ -1032,14 +1060,11 @@
 # wrong constant name writable_real?
 # wrong constant name zero?
 # uninitialized constant FileUtils::DryRun::LN_SUPPORTED
-# Did you mean?  FileUtils::DryRun::LN_SUPPORTED
-#                FileUtils::LN_SUPPORTED
+# Did you mean?  FileUtils::LN_SUPPORTED
 # uninitialized constant FileUtils::DryRun::RUBY
-# Did you mean?  FileUtils::DryRun::RUBY
-#                FileUtils::RUBY
+# Did you mean?  FileUtils::RUBY
 # uninitialized constant FileUtils::DryRun::VERSION
-# Did you mean?  FileUtils::DryRun::VERSION
-#                FileUtils::VERSION
+# Did you mean?  FileUtils::VERSION
 # wrong constant name blockdev?
 # wrong constant name chardev?
 # wrong constant name chmod
@@ -1054,6 +1079,7 @@
 # wrong constant name exist?
 # wrong constant name file?
 # wrong constant name initialize
+# wrong constant name link
 # wrong constant name lstat
 # wrong constant name lstat!
 # wrong constant name path
@@ -1073,23 +1099,17 @@
 # wrong constant name traverse
 # wrong constant name wrap_traverse
 # uninitialized constant FileUtils::NoWrite::LN_SUPPORTED
-# Did you mean?  FileUtils::NoWrite::LN_SUPPORTED
-#                FileUtils::LN_SUPPORTED
+# Did you mean?  FileUtils::LN_SUPPORTED
 # uninitialized constant FileUtils::NoWrite::RUBY
-# Did you mean?  FileUtils::NoWrite::RUBY
-#                FileUtils::RUBY
+# Did you mean?  FileUtils::RUBY
 # uninitialized constant FileUtils::NoWrite::VERSION
-# Did you mean?  FileUtils::NoWrite::VERSION
-#                FileUtils::VERSION
+# Did you mean?  FileUtils::VERSION
 # uninitialized constant FileUtils::Verbose::LN_SUPPORTED
-# Did you mean?  FileUtils::Verbose::LN_SUPPORTED
-#                FileUtils::LN_SUPPORTED
+# Did you mean?  FileUtils::LN_SUPPORTED
 # uninitialized constant FileUtils::Verbose::RUBY
-# Did you mean?  FileUtils::Verbose::RUBY
-#                FileUtils::RUBY
+# Did you mean?  FileUtils::RUBY
 # uninitialized constant FileUtils::Verbose::VERSION
-# Did you mean?  FileUtils::Verbose::VERSION
-#                FileUtils::VERSION
+# Did you mean?  FileUtils::VERSION
 # undefined singleton method `cp_r$1' for `FileUtils'
 # undefined singleton method `mkdir_p$1' for `FileUtils'
 # wrong constant name cd
@@ -1108,12 +1128,14 @@
 # wrong constant name copy_file
 # wrong constant name copy_stream
 # wrong constant name cp
+# wrong constant name cp_lr
 # wrong constant name cp_r$1
 # wrong constant name getwd
 # wrong constant name have_option?
 # wrong constant name identical?
 # wrong constant name install
 # wrong constant name link
+# wrong constant name link_entry
 # wrong constant name ln
 # wrong constant name ln_s
 # wrong constant name ln_sf
@@ -1143,8 +1165,17 @@
 # undefined method `rationalize$2' for class `Float'
 # Did you mean?  Rational
 # wrong constant name rationalize$2
-# uninitialized constant Forwardable
-# uninitialized constant Forwardable
+# wrong constant name def_delegator
+# wrong constant name def_delegators
+# wrong constant name def_instance_delegator
+# wrong constant name def_instance_delegators
+# wrong constant name delegate
+# wrong constant name instance_delegate
+# wrong constant name _compile_method
+# wrong constant name _delegator_method
+# wrong constant name _valid_method?
+# wrong constant name debug
+# wrong constant name debug=
 # wrong constant name <static-init>
 # wrong constant name garbage_collect
 # undefined singleton method `report$1' for `GC::Profiler'
@@ -1156,6 +1187,7 @@
 # wrong constant name stat$2
 # wrong constant name stress=
 # wrong constant name verify_internal_consistency
+# wrong constant name verify_transient_heap_internal_consistency
 # wrong constant name <Class:AvailableSet>
 # wrong constant name <Class:BundlerVersionFinder>
 # wrong constant name <Class:Command>
@@ -1250,7 +1282,6 @@
 # wrong constant name to_spec
 # wrong constant name version
 # wrong constant name default_specifications_dir
-# wrong constant name upstream_default_specifications_dir
 # wrong constant name <static-init>
 # wrong constant name bundler_version
 # wrong constant name bundler_version_with_reason
@@ -1453,28 +1484,20 @@
 # wrong constant name redirector
 # wrong constant name run
 # uninitialized constant Gem::Ext::CmakeBuilder::CHDIR_MONITOR
-# Did you mean?  Gem::Ext::CmakeBuilder::CHDIR_MONITOR
 # uninitialized constant Gem::Ext::CmakeBuilder::CHDIR_MUTEX
-# Did you mean?  Gem::Ext::CmakeBuilder::CHDIR_MUTEX
 # wrong constant name <static-init>
 # wrong constant name build
 # uninitialized constant Gem::Ext::ConfigureBuilder::CHDIR_MONITOR
-# Did you mean?  Gem::Ext::ConfigureBuilder::CHDIR_MONITOR
 # uninitialized constant Gem::Ext::ConfigureBuilder::CHDIR_MUTEX
-# Did you mean?  Gem::Ext::ConfigureBuilder::CHDIR_MUTEX
 # wrong constant name <static-init>
 # wrong constant name build
 # uninitialized constant Gem::Ext::ExtConfBuilder::CHDIR_MONITOR
-# Did you mean?  Gem::Ext::ExtConfBuilder::CHDIR_MONITOR
 # uninitialized constant Gem::Ext::ExtConfBuilder::CHDIR_MUTEX
-# Did you mean?  Gem::Ext::ExtConfBuilder::CHDIR_MUTEX
 # wrong constant name <static-init>
 # wrong constant name build
 # wrong constant name get_relative_path
 # uninitialized constant Gem::Ext::RakeBuilder::CHDIR_MONITOR
-# Did you mean?  Gem::Ext::RakeBuilder::CHDIR_MONITOR
 # uninitialized constant Gem::Ext::RakeBuilder::CHDIR_MUTEX
-# Did you mean?  Gem::Ext::RakeBuilder::CHDIR_MUTEX
 # wrong constant name <static-init>
 # wrong constant name build
 # wrong constant name <static-init>
@@ -1529,7 +1552,7 @@
 # wrong constant name spec_file
 # wrong constant name unpack
 # wrong constant name verify_gem_home
-# wrong constant name verify_spec_name
+# wrong constant name verify_spec
 # wrong constant name windows_stub_script
 # wrong constant name write_build_info_file
 # wrong constant name write_cache_file
@@ -2420,14 +2443,21 @@
 # wrong constant name hexdigest
 # wrong constant name <static-init>
 # wrong constant name d
+# wrong constant name d=
 # wrong constant name dmp1
+# wrong constant name dmp1=
 # wrong constant name dmq1
+# wrong constant name dmq1=
 # wrong constant name e
+# wrong constant name e=
 # wrong constant name export
 # wrong constant name initialize
 # wrong constant name iqmp
+# wrong constant name iqmp=
 # wrong constant name n
+# wrong constant name n=
 # wrong constant name p
+# wrong constant name p=
 # wrong constant name params
 # wrong constant name private?
 # wrong constant name private_decrypt
@@ -2437,6 +2467,7 @@
 # wrong constant name public_encrypt
 # wrong constant name public_key
 # wrong constant name q
+# wrong constant name q=
 # wrong constant name set_crt_params
 # wrong constant name set_factors
 # wrong constant name set_key
@@ -2530,7 +2561,6 @@
 # wrong constant name uri
 # uninitialized constant Gem::Source::Git::FILES
 # Did you mean?  File
-#                Gem::Source::Git::FILES
 #                Gem::Source::FILES
 # wrong constant name base_dir
 # wrong constant name cache
@@ -2554,14 +2584,12 @@
 # wrong constant name <static-init>
 # uninitialized constant Gem::Source::Installed::FILES
 # Did you mean?  File
-#                Gem::Source::Installed::FILES
 #                Gem::Source::FILES
 # wrong constant name download
 # wrong constant name initialize
 # wrong constant name <static-init>
 # uninitialized constant Gem::Source::Local::FILES
 # Did you mean?  File
-#                Gem::Source::Local::FILES
 #                Gem::Source::FILES
 # wrong constant name download
 # wrong constant name fetch_spec
@@ -2570,15 +2598,12 @@
 # wrong constant name <static-init>
 # uninitialized constant Gem::Source::Lock::FILES
 # Did you mean?  File
-#                Gem::Source::Lock::FILES
 #                Gem::Source::FILES
 # wrong constant name initialize
 # wrong constant name wrapped
 # wrong constant name <static-init>
 # uninitialized constant Gem::Source::SpecificFile::FILES
-# Did you mean?  File
-#                Gem::Source::SpecificFile::FILES
-#                Gem::Source::FILES
+# Did you mean?  Gem::Source::FILES
 # wrong constant name fetch_spec
 # wrong constant name initialize
 # wrong constant name load_specs
@@ -2587,7 +2612,6 @@
 # wrong constant name <static-init>
 # uninitialized constant Gem::Source::Vendor::FILES
 # Did you mean?  File
-#                Gem::Source::Vendor::FILES
 #                Gem::Source::FILES
 # wrong constant name initialize
 # wrong constant name <static-init>
@@ -2634,9 +2658,7 @@
 # wrong constant name <=>
 # wrong constant name ==
 # uninitialized constant Gem::Specification::GENERICS
-# Did you mean?  Gem::Specification::GENERICS
 # uninitialized constant Gem::Specification::GENERIC_CACHE
-# Did you mean?  Gem::Specification::GENERIC_CACHE
 # wrong constant name _deprecated_default_executable
 # wrong constant name _deprecated_default_executable=
 # wrong constant name _deprecated_has_rdoc
@@ -3029,9 +3051,6 @@
 # wrong constant name time
 # wrong constant name try_activate
 # wrong constant name ui
-# wrong constant name upstream_default_bindir
-# wrong constant name upstream_default_dir
-# wrong constant name upstream_default_path
 # wrong constant name use_gemdeps
 # wrong constant name use_paths
 # wrong constant name user_dir
@@ -3043,6 +3062,7 @@
 # undefined method `fetch$2' for class `Hash'
 # undefined method `initialize$2' for class `Hash'
 # Did you mean?  initialize
+# undefined method `merge$2' for class `Hash'
 # wrong constant name <
 # wrong constant name <=
 # wrong constant name >
@@ -3055,9 +3075,11 @@
 # wrong constant name dig
 # wrong constant name fetch$2
 # wrong constant name fetch_values
+# wrong constant name filter!
 # wrong constant name flatten
 # wrong constant name index
 # wrong constant name initialize$2
+# wrong constant name merge$2
 # wrong constant name merge!
 # wrong constant name replace
 # wrong constant name slice
@@ -3293,6 +3315,7 @@
 # undefined method `methods$1' for module `Kernel'
 # Did you mean?  methods
 #                method
+#                method
 # undefined method `private_methods$1' for module `Kernel'
 # Did you mean?  private_methods
 # undefined method `protected_methods$1' for module `Kernel'
@@ -3309,7 +3332,6 @@
 #                singleton_method
 # undefined method `to_enum$2' for module `Kernel'
 # Did you mean?  to_enum
-# wrong constant name class
 # wrong constant name clone$1
 # wrong constant name define_singleton_method$2
 # wrong constant name display$1
@@ -3328,6 +3350,7 @@
 # wrong constant name respond_to?
 # wrong constant name send$2
 # wrong constant name singleton_methods$1
+# wrong constant name then
 # wrong constant name to_enum$2
 # wrong constant name yield_self
 # wrong constant name at_exit
@@ -3346,7 +3369,9 @@
 # wrong constant name log$1
 # uninitialized constant MessagePack
 # uninitialized constant MessagePack
+# wrong constant name <<
 # wrong constant name ===
+# wrong constant name >>
 # wrong constant name []
 # wrong constant name arity
 # wrong constant name clone
@@ -3359,157 +3384,6 @@
 # wrong constant name source_location
 # wrong constant name super_method
 # wrong constant name unbind
-# wrong constant name _synchronize
-# wrong constant name assert
-# wrong constant name assert_empty
-# wrong constant name assert_equal
-# wrong constant name assert_in_delta
-# wrong constant name assert_in_epsilon
-# wrong constant name assert_includes
-# wrong constant name assert_instance_of
-# wrong constant name assert_kind_of
-# wrong constant name assert_match
-# wrong constant name assert_mock
-# wrong constant name assert_nil
-# wrong constant name assert_operator
-# wrong constant name assert_output
-# wrong constant name assert_predicate
-# wrong constant name assert_raises
-# wrong constant name assert_respond_to
-# wrong constant name assert_same
-# wrong constant name assert_send
-# wrong constant name assert_silent
-# wrong constant name assert_throws
-# wrong constant name capture_io
-# wrong constant name capture_subprocess_io
-# wrong constant name diff
-# wrong constant name exception_details
-# wrong constant name flunk
-# wrong constant name message
-# wrong constant name mu_pp
-# wrong constant name mu_pp_for_diff
-# wrong constant name pass
-# wrong constant name refute
-# wrong constant name refute_empty
-# wrong constant name refute_equal
-# wrong constant name refute_in_delta
-# wrong constant name refute_in_epsilon
-# wrong constant name refute_includes
-# wrong constant name refute_instance_of
-# wrong constant name refute_kind_of
-# wrong constant name refute_match
-# wrong constant name refute_nil
-# wrong constant name refute_operator
-# wrong constant name refute_predicate
-# wrong constant name refute_respond_to
-# wrong constant name refute_same
-# wrong constant name skip
-# wrong constant name skipped?
-# wrong constant name <static-init>
-# wrong constant name diff
-# wrong constant name diff=
-# wrong constant name must_be
-# wrong constant name must_be_close_to
-# wrong constant name must_be_empty
-# wrong constant name must_be_instance_of
-# wrong constant name must_be_kind_of
-# wrong constant name must_be_nil
-# wrong constant name must_be_same_as
-# wrong constant name must_be_silent
-# wrong constant name must_be_within_delta
-# wrong constant name must_be_within_epsilon
-# wrong constant name must_equal
-# wrong constant name must_include
-# wrong constant name must_match
-# wrong constant name must_output
-# wrong constant name must_raise
-# wrong constant name must_respond_to
-# wrong constant name must_throw
-# wrong constant name wont_be
-# wrong constant name wont_be_close_to
-# wrong constant name wont_be_empty
-# wrong constant name wont_be_instance_of
-# wrong constant name wont_be_kind_of
-# wrong constant name wont_be_nil
-# wrong constant name wont_be_same_as
-# wrong constant name wont_be_within_delta
-# wrong constant name wont_be_within_epsilon
-# wrong constant name wont_equal
-# wrong constant name wont_include
-# wrong constant name wont_match
-# wrong constant name wont_respond_to
-# wrong constant name <static-init>
-# wrong constant name jruby?
-# wrong constant name maglev?
-# wrong constant name mri?
-# wrong constant name rubinius?
-# wrong constant name windows?
-# wrong constant name <static-init>
-# wrong constant name assertions
-# wrong constant name assertions=
-# wrong constant name failure
-# wrong constant name failures
-# wrong constant name failures=
-# wrong constant name initialize
-# wrong constant name marshal_dump
-# wrong constant name marshal_load
-# wrong constant name name
-# wrong constant name name=
-# wrong constant name passed?
-# wrong constant name result_code
-# wrong constant name run
-# wrong constant name skipped?
-# wrong constant name <static-init>
-# wrong constant name inherited
-# wrong constant name methods_matching
-# wrong constant name on_signal
-# wrong constant name reset
-# wrong constant name run
-# wrong constant name run_one_method
-# wrong constant name runnable_methods
-# wrong constant name runnables
-# wrong constant name with_info_handler
-# uninitialized constant Minitest::Test::E
-# Did you mean?  Minitest::Test::E
-# wrong constant name <Class:LifecycleHooks>
-# uninitialized constant Minitest::Test::SIGNALS
-# Did you mean?  Signal
-#                Minitest::Test::SIGNALS
-# uninitialized constant Minitest::Test::UNDEFINED
-# Did you mean?  Minitest::Test::UNDEFINED
-# wrong constant name capture_exceptions
-# wrong constant name error?
-# wrong constant name location
-# wrong constant name time
-# wrong constant name time=
-# wrong constant name time_it
-# wrong constant name with_info_handler
-# wrong constant name after_setup
-# wrong constant name after_teardown
-# wrong constant name before_setup
-# wrong constant name before_teardown
-# wrong constant name setup
-# wrong constant name teardown
-# wrong constant name <static-init>
-# wrong constant name <static-init>
-# wrong constant name i_suck_and_my_tests_are_order_dependent!
-# wrong constant name io_lock
-# wrong constant name io_lock=
-# wrong constant name make_my_diffs_pretty!
-# wrong constant name parallelize_me!
-# wrong constant name test_order
-# uninitialized constant Minitest::Unit::TestCase::E
-# Did you mean?  Minitest::Unit::TestCase::E
-# uninitialized constant Minitest::Unit::TestCase::PASSTHROUGH_EXCEPTIONS
-# Did you mean?  Minitest::Unit::TestCase::PASSTHROUGH_EXCEPTIONS
-# uninitialized constant Minitest::Unit::TestCase::SIGNALS
-# Did you mean?  Signal
-#                Minitest::Unit::TestCase::SIGNALS
-# uninitialized constant Minitest::Unit::TestCase::TEARDOWN_METHODS
-# Did you mean?  Minitest::Unit::TestCase::TEARDOWN_METHODS
-# uninitialized constant Minitest::Unit::TestCase::UNDEFINED
-# Did you mean?  Minitest::Unit::TestCase::UNDEFINED
-# wrong constant name <static-init>
 # undefined method `class_eval$1' for class `Module'
 # Did you mean?  class_eval
 # undefined method `class_variables$1' for class `Module'
@@ -3528,15 +3402,24 @@
 # undefined method `instance_methods$1' for class `Module'
 # Did you mean?  instance_methods
 #                instance_method
+# undefined method `method_defined?$1' for class `Module'
+# Did you mean?  method_defined?
+#                method_undefined
 # undefined method `module_eval$1' for class `Module'
 # Did you mean?  module_eval
 # undefined method `private_instance_methods$1' for class `Module'
 # Did you mean?  private_instance_methods
+# undefined method `private_method_defined?$1' for class `Module'
+# Did you mean?  private_method_defined?
 # undefined method `protected_instance_methods$1' for class `Module'
 # Did you mean?  protected_instance_methods
+# undefined method `protected_method_defined?$1' for class `Module'
+# Did you mean?  protected_method_defined?
 # undefined method `public_instance_methods$1' for class `Module'
 # Did you mean?  public_instance_methods
 #                public_instance_method
+# undefined method `public_method_defined?$1' for class `Module'
+# Did you mean?  public_method_defined?
 # undefined method `remove_method$1' for class `Module'
 # Did you mean?  remove_method
 # wrong constant name class_eval$1
@@ -3546,12 +3429,15 @@
 # wrong constant name constants$1
 # wrong constant name define_method$2
 # wrong constant name deprecate_constant
-# wrong constant name infect_an_assertion
 # wrong constant name instance_methods$1
+# wrong constant name method_defined?$1
 # wrong constant name module_eval$1
 # wrong constant name private_instance_methods$1
+# wrong constant name private_method_defined?$1
 # wrong constant name protected_instance_methods$1
+# wrong constant name protected_method_defined?$1
 # wrong constant name public_instance_methods$1
+# wrong constant name public_method_defined?$1
 # wrong constant name remove_method$1
 # wrong constant name undef_method
 # wrong constant name used_modules
@@ -3575,6 +3461,8 @@
 # wrong constant name wait_until
 # wrong constant name wait_while
 # wrong constant name extend_object
+# uninitialized constant Mutex_m
+# uninitialized constant Mutex_m
 # wrong constant name name
 # wrong constant name receiver
 # uninitialized constant Net::FTP
@@ -3598,9 +3486,7 @@
 # uninitialized constant Net::FTPTempError
 # Did you mean?  TypeError
 # uninitialized constant Net::HTTP::DigestAuth
-# Did you mean?  Digest
 # uninitialized constant Net::HTTP::DigestAuth
-# Did you mean?  Digest
 # uninitialized constant Net::HTTP::Persistent
 # uninitialized constant Net::HTTP::Persistent
 # uninitialized constant Net::IMAP
@@ -3622,11 +3508,9 @@
 # uninitialized constant Net::SMTPServerBusy
 # uninitialized constant Net::SMTPServerBusy
 # uninitialized constant Net::SMTPSyntaxError
-# Did you mean?  SyntaxError
-#                Net::ProtoSyntaxError
+# Did you mean?  Net::ProtoSyntaxError
 # uninitialized constant Net::SMTPSyntaxError
-# Did you mean?  SyntaxError
-#                Net::ProtoSyntaxError
+# Did you mean?  Net::ProtoSyntaxError
 # uninitialized constant Net::SMTPUnknownError
 # uninitialized constant Net::SMTPUnknownError
 # uninitialized constant Net::SMTPUnsupportedCommand
@@ -3652,8 +3536,8 @@
 # wrong constant name step$2
 # wrong constant name truncate$1
 # uninitialized constant RUBYGEMS_ACTIVATION_MONITOR
-# Did you mean?  RUBYGEMS_ACTIVATION_MONITOR
-# wrong constant name stub
+# wrong constant name to_yaml
+# wrong constant name yaml_tag
 # wrong constant name <Class:Object>
 # wrong constant name []
 # wrong constant name []=
@@ -3672,14 +3556,6 @@
 # wrong constant name each_object$2
 # wrong constant name garbage_collect
 # wrong constant name undefine_finalizer
-# uninitialized constant OpenSSL::Digest::DSS
-# uninitialized constant OpenSSL::Digest::DSS
-# uninitialized constant OpenSSL::Digest::DSS1
-# uninitialized constant OpenSSL::Digest::DSS1
-# uninitialized constant OpenSSL::Digest::SHA
-# Did you mean?  OpenSSL::Digest::SHA1
-# uninitialized constant OpenSSL::Digest::SHA
-# Did you mean?  OpenSSL::Digest::SHA1
 # uninitialized constant OpenSSL::PKCS5::PKCS5Error
 # uninitialized constant OpenSSL::PKCS5::PKCS5Error
 # wrong constant name <Class:Acceptables>
@@ -3887,61 +3763,41 @@
 # undefined singleton method `glob$1' for `Pathname'
 # wrong constant name glob$1
 # undefined method `curry$1' for class `Proc'
+# wrong constant name <<
 # wrong constant name ===
+# wrong constant name >>
 # wrong constant name []
 # wrong constant name clone
 # wrong constant name curry$1
 # wrong constant name lambda?
 # wrong constant name yield
 # uninitialized constant Proc0
-# Did you mean?  Proc
 # uninitialized constant Proc0
-# Did you mean?  Proc
 # uninitialized constant Proc1
-# Did you mean?  Proc
 # uninitialized constant Proc1
-# Did you mean?  Proc
 # uninitialized constant Proc10
-# Did you mean?  Proc
 # uninitialized constant Proc10
-# Did you mean?  Proc
 # uninitialized constant Proc2
-# Did you mean?  Proc
 # uninitialized constant Proc2
-# Did you mean?  Proc
 # uninitialized constant Proc3
-# Did you mean?  Proc
 # uninitialized constant Proc3
-# Did you mean?  Proc
 # uninitialized constant Proc4
-# Did you mean?  Proc
 # uninitialized constant Proc4
-# Did you mean?  Proc
 # uninitialized constant Proc5
-# Did you mean?  Proc
 # uninitialized constant Proc5
-# Did you mean?  Proc
 # uninitialized constant Proc6
-# Did you mean?  Proc
 # uninitialized constant Proc6
-# Did you mean?  Proc
 # uninitialized constant Proc7
-# Did you mean?  Proc
 # uninitialized constant Proc7
-# Did you mean?  Proc
 # uninitialized constant Proc8
-# Did you mean?  Proc
 # uninitialized constant Proc8
-# Did you mean?  Proc
 # uninitialized constant Proc9
-# Did you mean?  Proc
 # uninitialized constant Proc9
-# Did you mean?  Proc
-# undefined singleton method `setrgid$1' for `Process::Sys'
-# undefined singleton method `setruid$1' for `Process::Sys'
+# undefined singleton method `setresgid$1' for `Process::Sys'
+# undefined singleton method `setresuid$1' for `Process::Sys'
 # wrong constant name getegid
-# wrong constant name setrgid$1
-# wrong constant name setruid$1
+# wrong constant name setresgid$1
+# wrong constant name setresuid$1
 # wrong constant name cstime
 # wrong constant name cstime=
 # wrong constant name cutime
@@ -3974,35 +3830,422 @@
 # wrong constant name wait2$1
 # wrong constant name waitpid$1
 # wrong constant name waitpid2$1
-# uninitialized constant RDoc::TestCase::E
-# Did you mean?  RDoc::TestCase::E
-# uninitialized constant RDoc::TestCase::PASSTHROUGH_EXCEPTIONS
-# Did you mean?  RDoc::TestCase::PASSTHROUGH_EXCEPTIONS
-# uninitialized constant RDoc::TestCase::SIGNALS
-# Did you mean?  Signal
-#                RDoc::TestCase::SIGNALS
-# uninitialized constant RDoc::TestCase::TEARDOWN_METHODS
-# Did you mean?  RDoc::TestCase::TEARDOWN_METHODS
-# uninitialized constant RDoc::TestCase::UNDEFINED
-# Did you mean?  RDoc::TestCase::UNDEFINED
-# wrong constant name assert_directory
-# wrong constant name assert_file
-# wrong constant name blank_line
-# wrong constant name block
-# wrong constant name comment
-# wrong constant name doc
-# wrong constant name hard_break
-# wrong constant name head
-# wrong constant name item
-# wrong constant name list
-# wrong constant name para
-# wrong constant name raw
-# wrong constant name refute_file
-# wrong constant name rule
-# wrong constant name temp_dir
-# wrong constant name verb
-# wrong constant name verbose_capture_io
+# wrong constant name <Class:BadAlias>
+# wrong constant name <Class:ClassLoader>
+# wrong constant name <Class:Coder>
+# wrong constant name <Class:DisallowedClass>
+# wrong constant name <Class:Emitter>
+# wrong constant name <Class:Exception>
+# wrong constant name <Class:Handler>
+# wrong constant name <Class:Handlers>
+# wrong constant name <Class:JSON>
+# wrong constant name <Class:Nodes>
+# wrong constant name <Class:Omap>
+# wrong constant name <Class:Parser>
+# wrong constant name <Class:ScalarScanner>
+# wrong constant name <Class:Set>
+# wrong constant name <Class:Stream>
+# wrong constant name <Class:Streaming>
+# wrong constant name <Class:SyntaxError>
+# wrong constant name <Class:TreeBuilder>
+# wrong constant name <Class:Visitors>
 # wrong constant name <static-init>
+# wrong constant name <Class:Restricted>
+# wrong constant name big_decimal
+# wrong constant name complex
+# wrong constant name date
+# wrong constant name date_time
+# wrong constant name exception
+# wrong constant name load
+# wrong constant name object
+# wrong constant name psych_omap
+# wrong constant name psych_set
+# wrong constant name range
+# wrong constant name rational
+# wrong constant name regexp
+# wrong constant name struct
+# wrong constant name symbol
+# wrong constant name symbolize
+# uninitialized constant Psych::ClassLoader::Restricted::BIG_DECIMAL
+# Did you mean?  BigDecimal
+#                Psych::ClassLoader::BIG_DECIMAL
+# uninitialized constant Psych::ClassLoader::Restricted::CACHE
+# Did you mean?  Psych::ClassLoader::CACHE
+# uninitialized constant Psych::ClassLoader::Restricted::COMPLEX
+# Did you mean?  Complex
+#                Psych::ClassLoader::COMPLEX
+# uninitialized constant Psych::ClassLoader::Restricted::DATE
+# Did you mean?  Date
+#                Data
+#                Psych::ClassLoader::DATE
+# uninitialized constant Psych::ClassLoader::Restricted::DATE_TIME
+# Did you mean?  DateTime
+#                Psych::ClassLoader::DATE_TIME
+# uninitialized constant Psych::ClassLoader::Restricted::EXCEPTION
+# Did you mean?  Psych::Exception
+#                Exception
+#                Psych::ClassLoader::EXCEPTION
+# uninitialized constant Psych::ClassLoader::Restricted::OBJECT
+# Did you mean?  Object
+#                Psych::ClassLoader::OBJECT
+# uninitialized constant Psych::ClassLoader::Restricted::PSYCH_OMAP
+# Did you mean?  Psych::ClassLoader::PSYCH_OMAP
+# uninitialized constant Psych::ClassLoader::Restricted::PSYCH_SET
+# Did you mean?  Psych::ClassLoader::PSYCH_SET
+# uninitialized constant Psych::ClassLoader::Restricted::RANGE
+# Did you mean?  Range
+#                Psych::ClassLoader::RANGE
+# uninitialized constant Psych::ClassLoader::Restricted::RATIONAL
+# Did you mean?  Rational
+#                Psych::ClassLoader::RATIONAL
+# uninitialized constant Psych::ClassLoader::Restricted::REGEXP
+# Did you mean?  Regexp
+#                Psych::ClassLoader::REGEXP
+# uninitialized constant Psych::ClassLoader::Restricted::STRUCT
+# Did you mean?  Struct
+#                Psych::ClassLoader::STRUCT
+# uninitialized constant Psych::ClassLoader::Restricted::SYMBOL
+# Did you mean?  Symbol
+#                Psych::ClassLoader::SYMBOL
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name []=
+# wrong constant name add
+# wrong constant name implicit
+# wrong constant name implicit=
+# wrong constant name initialize
+# wrong constant name map
+# wrong constant name map=
+# wrong constant name object
+# wrong constant name object=
+# wrong constant name represent_map
+# wrong constant name represent_object
+# wrong constant name represent_scalar
+# wrong constant name represent_seq
+# wrong constant name scalar
+# wrong constant name scalar=
+# wrong constant name seq
+# wrong constant name seq=
+# wrong constant name style
+# wrong constant name style=
+# wrong constant name tag
+# wrong constant name tag=
+# wrong constant name type
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant Psych::Emitter::EVENTS
+# uninitialized constant Psych::Emitter::OPTIONS
+# wrong constant name alias
+# wrong constant name canonical
+# wrong constant name canonical=
+# wrong constant name end_document
+# wrong constant name indentation
+# wrong constant name indentation=
+# wrong constant name initialize
+# wrong constant name line_width
+# wrong constant name line_width=
+# wrong constant name scalar
+# wrong constant name start_document
+# wrong constant name start_mapping
+# wrong constant name start_sequence
+# wrong constant name start_stream
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <Class:DumperOptions>
+# wrong constant name alias
+# wrong constant name empty
+# wrong constant name end_document
+# wrong constant name end_mapping
+# wrong constant name end_sequence
+# wrong constant name end_stream
+# wrong constant name event_location
+# wrong constant name scalar
+# wrong constant name start_document
+# wrong constant name start_mapping
+# wrong constant name start_sequence
+# wrong constant name start_stream
+# wrong constant name streaming?
+# wrong constant name canonical
+# wrong constant name canonical=
+# wrong constant name indentation
+# wrong constant name indentation=
+# wrong constant name line_width
+# wrong constant name line_width=
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <Class:DocumentStream>
+# uninitialized constant Psych::Handlers::DocumentStream::EVENTS
+# uninitialized constant Psych::Handlers::DocumentStream::OPTIONS
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <Class:RubyEvents>
+# wrong constant name <Class:Stream>
+# wrong constant name <Class:TreeBuilder>
+# wrong constant name <Class:YAMLEvents>
+# wrong constant name visit_DateTime
+# wrong constant name visit_String
+# wrong constant name visit_Symbol
+# wrong constant name visit_Time
+# wrong constant name <static-init>
+# uninitialized constant Psych::JSON::Stream::DISPATCH
+# wrong constant name <Class:Emitter>
+# uninitialized constant Psych::JSON::Stream::Emitter::EVENTS
+# uninitialized constant Psych::JSON::Stream::Emitter::OPTIONS
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# uninitialized constant Psych::JSON::TreeBuilder::EVENTS
+# uninitialized constant Psych::JSON::TreeBuilder::OPTIONS
+# wrong constant name <static-init>
+# wrong constant name end_document
+# wrong constant name scalar
+# wrong constant name start_document
+# wrong constant name start_mapping
+# wrong constant name start_sequence
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <Class:Alias>
+# wrong constant name <Class:Document>
+# wrong constant name <Class:Mapping>
+# wrong constant name <Class:Node>
+# wrong constant name <Class:Scalar>
+# wrong constant name <Class:Sequence>
+# wrong constant name <Class:Stream>
+# uninitialized constant Psych::Nodes::Alias::Elem
+# wrong constant name anchor
+# wrong constant name anchor=
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant Psych::Nodes::Document::Elem
+# wrong constant name implicit
+# wrong constant name implicit=
+# wrong constant name implicit_end
+# wrong constant name implicit_end=
+# wrong constant name initialize
+# wrong constant name root
+# wrong constant name tag_directives
+# wrong constant name tag_directives=
+# wrong constant name version
+# wrong constant name version=
+# wrong constant name <static-init>
+# uninitialized constant Psych::Nodes::Mapping::Elem
+# wrong constant name anchor
+# wrong constant name anchor=
+# wrong constant name implicit
+# wrong constant name implicit=
+# wrong constant name initialize
+# wrong constant name style
+# wrong constant name style=
+# wrong constant name tag=
+# wrong constant name <static-init>
+# uninitialized constant Psych::Nodes::Node::Elem
+# wrong constant name alias?
+# wrong constant name children
+# wrong constant name document?
+# wrong constant name each
+# wrong constant name end_column
+# wrong constant name end_column=
+# wrong constant name end_line
+# wrong constant name end_line=
+# wrong constant name mapping?
+# wrong constant name scalar?
+# wrong constant name sequence?
+# wrong constant name start_column
+# wrong constant name start_column=
+# wrong constant name start_line
+# wrong constant name start_line=
+# wrong constant name stream?
+# wrong constant name tag
+# wrong constant name to_ruby
+# wrong constant name to_yaml
+# wrong constant name transform
+# wrong constant name yaml
+# wrong constant name <static-init>
+# uninitialized constant Psych::Nodes::Scalar::Elem
+# wrong constant name anchor
+# wrong constant name anchor=
+# wrong constant name initialize
+# wrong constant name plain
+# wrong constant name plain=
+# wrong constant name quoted
+# wrong constant name quoted=
+# wrong constant name style
+# wrong constant name style=
+# wrong constant name tag=
+# wrong constant name value
+# wrong constant name value=
+# wrong constant name <static-init>
+# uninitialized constant Psych::Nodes::Sequence::Elem
+# wrong constant name anchor
+# wrong constant name anchor=
+# wrong constant name implicit
+# wrong constant name implicit=
+# wrong constant name initialize
+# wrong constant name style
+# wrong constant name style=
+# wrong constant name tag=
+# wrong constant name <static-init>
+# uninitialized constant Psych::Nodes::Stream::Elem
+# wrong constant name encoding
+# wrong constant name encoding=
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# uninitialized constant Psych::Omap::Elem
+# uninitialized constant Psych::Omap::K
+# uninitialized constant Psych::Omap::V
+# wrong constant name <static-init>
+# wrong constant name <Class:Mark>
+# wrong constant name external_encoding=
+# wrong constant name handler
+# wrong constant name handler=
+# wrong constant name initialize
+# wrong constant name mark
+# wrong constant name parse
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name class_loader
+# wrong constant name initialize
+# wrong constant name parse_int
+# wrong constant name parse_time
+# wrong constant name tokenize
+# wrong constant name <static-init>
+# uninitialized constant Psych::Set::Elem
+# uninitialized constant Psych::Set::K
+# uninitialized constant Psych::Set::V
+# wrong constant name <static-init>
+# uninitialized constant Psych::Stream::DISPATCH
+# wrong constant name <Class:Emitter>
+# uninitialized constant Psych::Stream::Emitter::EVENTS
+# uninitialized constant Psych::Stream::Emitter::OPTIONS
+# wrong constant name end_document
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <Class:ClassMethods>
+# wrong constant name start
+# wrong constant name new
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name column
+# wrong constant name context
+# wrong constant name file
+# wrong constant name initialize
+# wrong constant name line
+# wrong constant name offset
+# wrong constant name problem
+# wrong constant name <static-init>
+# uninitialized constant Psych::TreeBuilder::EVENTS
+# uninitialized constant Psych::TreeBuilder::OPTIONS
+# wrong constant name end_document
+# wrong constant name root
+# wrong constant name <static-init>
+# wrong constant name <Class:DepthFirst>
+# wrong constant name <Class:Emitter>
+# wrong constant name <Class:JSONTree>
+# wrong constant name <Class:NoAliasRuby>
+# wrong constant name <Class:ToRuby>
+# wrong constant name <Class:Visitor>
+# wrong constant name <Class:YAMLTree>
+# uninitialized constant Psych::Visitors::DepthFirst::DISPATCH
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant Psych::Visitors::Emitter::DISPATCH
+# wrong constant name initialize
+# wrong constant name visit_Psych_Nodes_Alias
+# wrong constant name visit_Psych_Nodes_Document
+# wrong constant name visit_Psych_Nodes_Mapping
+# wrong constant name visit_Psych_Nodes_Scalar
+# wrong constant name visit_Psych_Nodes_Sequence
+# wrong constant name visit_Psych_Nodes_Stream
+# wrong constant name <static-init>
+# uninitialized constant Psych::Visitors::JSONTree::DISPATCH
+# wrong constant name <static-init>
+# wrong constant name create
+# uninitialized constant Psych::Visitors::NoAliasRuby::DISPATCH
+# uninitialized constant Psych::Visitors::NoAliasRuby::SHOVEL
+# wrong constant name <static-init>
+# uninitialized constant Psych::Visitors::ToRuby::DISPATCH
+# wrong constant name class_loader
+# wrong constant name initialize
+# wrong constant name visit_Psych_Nodes_Alias
+# wrong constant name visit_Psych_Nodes_Document
+# wrong constant name visit_Psych_Nodes_Mapping
+# wrong constant name visit_Psych_Nodes_Scalar
+# wrong constant name visit_Psych_Nodes_Sequence
+# wrong constant name visit_Psych_Nodes_Stream
+# wrong constant name <static-init>
+# wrong constant name create
+# wrong constant name accept
+# wrong constant name <static-init>
+# wrong constant name <<
+# uninitialized constant Psych::Visitors::YAMLTree::DISPATCH
+# wrong constant name finish
+# wrong constant name finished
+# wrong constant name finished?
+# wrong constant name initialize
+# wrong constant name push
+# wrong constant name start
+# wrong constant name started
+# wrong constant name started?
+# wrong constant name tree
+# wrong constant name visit_Array
+# wrong constant name visit_BasicObject
+# wrong constant name visit_BigDecimal
+# wrong constant name visit_Class
+# wrong constant name visit_Complex
+# wrong constant name visit_Date
+# wrong constant name visit_DateTime
+# wrong constant name visit_Delegator
+# wrong constant name visit_Encoding
+# wrong constant name visit_Enumerator
+# wrong constant name visit_Exception
+# wrong constant name visit_FalseClass
+# wrong constant name visit_Float
+# wrong constant name visit_Hash
+# wrong constant name visit_Integer
+# wrong constant name visit_Module
+# wrong constant name visit_NameError
+# wrong constant name visit_NilClass
+# wrong constant name visit_Object
+# wrong constant name visit_Psych_Omap
+# wrong constant name visit_Psych_Set
+# wrong constant name visit_Range
+# wrong constant name visit_Rational
+# wrong constant name visit_Regexp
+# wrong constant name visit_String
+# wrong constant name visit_Struct
+# wrong constant name visit_Symbol
+# wrong constant name visit_Time
+# wrong constant name visit_TrueClass
+# wrong constant name <static-init>
+# wrong constant name create
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name add_builtin_type
+# wrong constant name add_domain_type
+# wrong constant name add_tag
+# wrong constant name domain_types
+# wrong constant name domain_types=
+# wrong constant name dump
+# wrong constant name dump_stream
+# wrong constant name dump_tags
+# wrong constant name dump_tags=
+# wrong constant name libyaml_version
+# wrong constant name load
+# wrong constant name load_file
+# wrong constant name load_stream
+# wrong constant name load_tags
+# wrong constant name load_tags=
+# wrong constant name parse
+# wrong constant name parse_file
+# wrong constant name parse_stream
+# wrong constant name parser
+# wrong constant name remove_type
+# wrong constant name safe_load
+# wrong constant name to_json
 # wrong constant name expand_tabs
 # wrong constant name flush_left
 # wrong constant name markup
@@ -4016,10 +4259,11 @@
 # wrong constant name wrap
 # wrong constant name <static-init>
 # wrong constant name encode_fallback
+# uninitialized constant RSpec::Core::ExampleGroup::BE_PREDICATE_REGEX
+# uninitialized constant RSpec::Core::ExampleGroup::DYNAMIC_MATCHER_REGEX
+# uninitialized constant RSpec::Core::ExampleGroup::HAS_REGEX
 # uninitialized constant RSpec::Core::ExampleGroup::NOT_YET_IMPLEMENTED
-# Did you mean?  RSpec::Core::ExampleGroup::NOT_YET_IMPLEMENTED
 # uninitialized constant RSpec::Core::ExampleGroup::NO_REASON_GIVEN
-# Did you mean?  RSpec::Core::ExampleGroup::NO_REASON_GIVEN
 # wrong constant name initialize
 # wrong constant name persist
 # wrong constant name <static-init>
@@ -4117,6 +4361,512 @@
 # wrong constant name members
 # wrong constant name <static-init>
 # wrong constant name record
+# wrong constant name <Class:AmbiguousTargetError>
+# wrong constant name <Class:BlockLocator>
+# wrong constant name <Class:BlockTokenExtractor>
+# wrong constant name <Class:Error>
+# wrong constant name <Class:TargetNotFoundError>
+# wrong constant name body_content_lines
+# wrong constant name initialize
+# wrong constant name method_name
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Expectations::BlockSnippetExtractor::BlockLocator::Elem
+# wrong constant name beginning_line_number
+# wrong constant name beginning_line_number=
+# wrong constant name body_content_locations
+# wrong constant name method_call_location
+# wrong constant name method_name
+# wrong constant name method_name=
+# wrong constant name source
+# wrong constant name source=
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# uninitialized constant RSpec::Expectations::BlockSnippetExtractor::BlockTokenExtractor::Elem
+# wrong constant name beginning_line_number
+# wrong constant name beginning_line_number=
+# wrong constant name body_tokens
+# wrong constant name method_name
+# wrong constant name method_name=
+# wrong constant name source
+# wrong constant name source=
+# wrong constant name state
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name try_extracting_single_line_body_of
+# wrong constant name aggregate
+# wrong constant name block_label
+# wrong constant name call
+# wrong constant name failures
+# wrong constant name initialize
+# wrong constant name metadata
+# wrong constant name other_errors
+# wrong constant name <static-init>
+# wrong constant name aggregation_block_label
+# wrong constant name aggregation_metadata
+# wrong constant name all_exceptions
+# wrong constant name exception_count_description
+# wrong constant name failures
+# wrong constant name initialize
+# wrong constant name other_errors
+# wrong constant name summary
+# wrong constant name log
+# wrong constant name not_log
+# uninitialized constant RSpec::Matchers::BuiltIn::All::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name failed_objects
+# wrong constant name initialize
+# wrong constant name matcher
+# wrong constant name <static-init>
+# wrong constant name <
+# wrong constant name <=
+# wrong constant name ==
+# wrong constant name ===
+# wrong constant name =~
+# wrong constant name >
+# wrong constant name >=
+# uninitialized constant RSpec::Matchers::BuiltIn::Be::UNDEFINED
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeAKindOf::UNDEFINED
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeAnInstanceOf::UNDEFINED
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeBetween::UNDEFINED
+# wrong constant name exclusive
+# wrong constant name inclusive
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeComparedTo::UNDEFINED
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeFalsey::UNDEFINED
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeNil::UNDEFINED
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BePredicate::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeTruthy::UNDEFINED
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::BeWithin::UNDEFINED
+# wrong constant name initialize
+# wrong constant name of
+# wrong constant name percent_of
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Change::UNDEFINED
+# wrong constant name by
+# wrong constant name by_at_least
+# wrong constant name by_at_most
+# wrong constant name does_not_match?
+# wrong constant name from
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name to
+# wrong constant name <static-init>
+# wrong constant name <Class:And>
+# wrong constant name <Class:NestedEvaluator>
+# wrong constant name <Class:Or>
+# wrong constant name <Class:SequentialEvaluator>
+# uninitialized constant RSpec::Matchers::BuiltIn::Compound::UNDEFINED
+# wrong constant name diffable_matcher_list
+# wrong constant name does_not_match?
+# wrong constant name evaluator
+# wrong constant name initialize
+# wrong constant name matcher_1
+# wrong constant name matcher_2
+# uninitialized constant RSpec::Matchers::BuiltIn::Compound::And::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Compound::UNDEFINED
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name matcher_matches?
+# wrong constant name <static-init>
+# wrong constant name matcher_expects_call_stack_jump?
+# uninitialized constant RSpec::Matchers::BuiltIn::Compound::Or::UNDEFINED
+# Did you mean?  RSpec::Matchers::BuiltIn::Compound::UNDEFINED
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name matcher_matches?
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name <Class:PairingsMaximizer>
+# uninitialized constant RSpec::Matchers::BuiltIn::ContainExactly::UNDEFINED
+# wrong constant name <Class:NullSolution>
+# wrong constant name <Class:Solution>
+# wrong constant name actual_to_expected_matched_indexes
+# wrong constant name expected_to_actual_matched_indexes
+# wrong constant name find_best_solution
+# wrong constant name initialize
+# wrong constant name solution
+# wrong constant name <static-init>
+# wrong constant name worse_than?
+# wrong constant name +
+# uninitialized constant #<Class:0x00007ff617c20640>::Elem
+# wrong constant name candidate?
+# wrong constant name ideal?
+# wrong constant name indeterminate_actual_indexes
+# wrong constant name indeterminate_actual_indexes=
+# wrong constant name indeterminate_expected_indexes
+# wrong constant name indeterminate_expected_indexes=
+# wrong constant name unmatched_actual_indexes
+# wrong constant name unmatched_actual_indexes=
+# wrong constant name unmatched_expected_indexes
+# wrong constant name unmatched_expected_indexes=
+# wrong constant name unmatched_item_count
+# wrong constant name worse_than?
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name members
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Cover::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::EndWith::UNDEFINED
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Eq::UNDEFINED
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Eql::UNDEFINED
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Equal::UNDEFINED
+# wrong constant name <static-init>
+# wrong constant name <Class:ExistenceTest>
+# uninitialized constant RSpec::Matchers::BuiltIn::Exist::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name actual_exists?
+# wrong constant name valid_test?
+# wrong constant name validity_message
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Has::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::HaveAttributes::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name respond_to_failed
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Include::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name expecteds
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Match::UNDEFINED
+# wrong constant name initialize
+# wrong constant name with_captures
+# wrong constant name <static-init>
+# wrong constant name __delegate_operator
+# wrong constant name <static-init>
+# wrong constant name !=
+# wrong constant name !~
+# wrong constant name <
+# wrong constant name <=
+# wrong constant name ==
+# wrong constant name ===
+# wrong constant name =~
+# wrong constant name >
+# wrong constant name >=
+# wrong constant name description
+# wrong constant name fail_with_message
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name get
+# wrong constant name register
+# wrong constant name registry
+# wrong constant name unregister
+# wrong constant name use_custom_matcher_or_delegate
+# uninitialized constant RSpec::Matchers::BuiltIn::Output::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name to_stderr
+# wrong constant name to_stderr_from_any_process
+# wrong constant name to_stdout
+# wrong constant name to_stdout_from_any_process
+# wrong constant name <static-init>
+# wrong constant name __delegate_operator
+# wrong constant name <static-init>
+# wrong constant name description
+# wrong constant name does_not_match?
+# wrong constant name expects_call_stack_jump?
+# wrong constant name failure_message
+# wrong constant name failure_message_when_negated
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name supports_block_expectations?
+# wrong constant name with_message
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::RespondTo::UNDEFINED
+# wrong constant name and_any_keywords
+# wrong constant name and_keywords
+# wrong constant name and_unlimited_arguments
+# wrong constant name argument
+# wrong constant name arguments
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name with
+# wrong constant name with_any_keywords
+# wrong constant name with_keywords
+# wrong constant name with_unlimited_arguments
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::Satisfy::UNDEFINED
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::StartOrEndWith::UNDEFINED
+# wrong constant name initialize
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::StartWith::UNDEFINED
+# wrong constant name <static-init>
+# wrong constant name description
+# wrong constant name does_not_match?
+# wrong constant name expects_call_stack_jump?
+# wrong constant name failure_message
+# wrong constant name failure_message_when_negated
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name supports_block_expectations?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::YieldControl::UNDEFINED
+# wrong constant name at_least
+# wrong constant name at_most
+# wrong constant name does_not_match?
+# wrong constant name exactly
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name once
+# wrong constant name thrice
+# wrong constant name times
+# wrong constant name twice
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::YieldSuccessiveArgs::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::YieldWithArgs::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Matchers::BuiltIn::YieldWithNoArgs::UNDEFINED
+# wrong constant name does_not_match?
+# wrong constant name matches?
+# wrong constant name <static-init>
+# wrong constant name <Class:AnyInstance>
+# wrong constant name <Class:ExpectChain>
+# wrong constant name <Class:MarshalExtension>
+# wrong constant name <Class:MessageChain>
+# wrong constant name <Class:StubChain>
+# wrong constant name <Class:Chain>
+# wrong constant name <Class:ErrorGenerator>
+# wrong constant name <Class:ExpectChainChain>
+# wrong constant name <Class:ExpectationChain>
+# wrong constant name <Class:FluentInterfaceProxy>
+# wrong constant name <Class:MessageChains>
+# wrong constant name <Class:PositiveExpectationChain>
+# wrong constant name <Class:Proxy>
+# wrong constant name <Class:Recorder>
+# wrong constant name <Class:StubChain>
+# wrong constant name <Class:StubChainChain>
+# wrong constant name <Class:Customizations>
+# wrong constant name constrained_to_any_of?
+# wrong constant name expectation_fulfilled!
+# wrong constant name initialize
+# wrong constant name matches_args?
+# wrong constant name never
+# wrong constant name playback!
+# wrong constant name and_call_original
+# wrong constant name and_raise
+# wrong constant name and_return
+# wrong constant name and_throw
+# wrong constant name and_wrap_original
+# wrong constant name and_yield
+# wrong constant name at_least
+# wrong constant name at_most
+# wrong constant name exactly
+# wrong constant name never
+# wrong constant name once
+# wrong constant name thrice
+# wrong constant name times
+# wrong constant name twice
+# wrong constant name with
+# wrong constant name <static-init>
+# wrong constant name record
+# wrong constant name <static-init>
+# wrong constant name raise_does_not_implement_error
+# wrong constant name raise_message_already_received_by_other_instance_error
+# wrong constant name raise_not_supported_with_prepend_error
+# wrong constant name raise_second_instance_received_message_error
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Mocks::AnyInstance::ExpectChainChain::EmptyInvocationOrder
+# Did you mean?  RSpec::Mocks::AnyInstance::ExpectChainChain::InvocationOrder
+# uninitialized constant RSpec::Mocks::AnyInstance::ExpectChainChain::InvocationOrder
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name expectation_fulfilled?
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name initialize
+# wrong constant name method_missing
+# wrong constant name <static-init>
+# wrong constant name []
+# wrong constant name add
+# wrong constant name all_expectations_fulfilled?
+# wrong constant name each_unfulfilled_expectation_matching
+# wrong constant name has_expectation?
+# wrong constant name playback!
+# wrong constant name received_expected_message!
+# wrong constant name remove_stub_chains_for!
+# wrong constant name unfulfilled_expectations
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name expect_chain
+# wrong constant name initialize
+# wrong constant name klass
+# wrong constant name should_not_receive
+# wrong constant name should_receive
+# wrong constant name stub
+# wrong constant name stub_chain
+# wrong constant name unstub
+# wrong constant name <static-init>
+# wrong constant name already_observing?
+# wrong constant name build_alias_method_name
+# wrong constant name expect_chain
+# wrong constant name initialize
+# wrong constant name instance_that_received
+# wrong constant name klass
+# wrong constant name message_chains
+# wrong constant name notify_received_message
+# wrong constant name playback!
+# wrong constant name should_not_receive
+# wrong constant name should_receive
+# wrong constant name stop_all_observation!
+# wrong constant name stop_observing!
+# wrong constant name stub
+# wrong constant name stub_chain
+# wrong constant name stubs
+# wrong constant name unstub
+# wrong constant name verify
+# wrong constant name <static-init>
+# wrong constant name expectation_fulfilled?
+# wrong constant name <static-init>
+# uninitialized constant RSpec::Mocks::AnyInstance::StubChainChain::EmptyInvocationOrder
+# Did you mean?  RSpec::Mocks::AnyInstance::StubChainChain::InvocationOrder
+# uninitialized constant RSpec::Mocks::AnyInstance::StubChainChain::InvocationOrder
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name error_generator
+# wrong constant name <static-init>
+# wrong constant name expect_chain_on
+# wrong constant name <static-init>
+# wrong constant name patch!
+# wrong constant name unpatch!
+# wrong constant name at_least
+# wrong constant name at_most
+# wrong constant name description
+# wrong constant name does_not_match?
+# wrong constant name exactly
+# wrong constant name failure_message
+# wrong constant name failure_message_when_negated
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name name
+# wrong constant name once
+# wrong constant name ordered
+# wrong constant name setup_allowance
+# wrong constant name setup_any_instance_allowance
+# wrong constant name setup_any_instance_expectation
+# wrong constant name setup_any_instance_negative_expectation
+# wrong constant name setup_expectation
+# wrong constant name setup_negative_expectation
+# wrong constant name thrice
+# wrong constant name times
+# wrong constant name twice
+# wrong constant name with
+# wrong constant name <static-init>
+# wrong constant name <Class:DefaultDescribable>
+# wrong constant name and_call_original
+# wrong constant name and_raise
+# wrong constant name and_return
+# wrong constant name and_throw
+# wrong constant name and_wrap_original
+# wrong constant name and_yield
+# wrong constant name at_least
+# wrong constant name at_most
+# wrong constant name description
+# wrong constant name does_not_match?
+# wrong constant name exactly
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name name
+# wrong constant name never
+# wrong constant name once
+# wrong constant name ordered
+# wrong constant name setup_allowance
+# wrong constant name setup_any_instance_allowance
+# wrong constant name setup_any_instance_expectation
+# wrong constant name setup_any_instance_negative_expectation
+# wrong constant name setup_expectation
+# wrong constant name setup_negative_expectation
+# wrong constant name thrice
+# wrong constant name times
+# wrong constant name twice
+# wrong constant name with
+# wrong constant name description_for
+# wrong constant name initialize
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name and_call_original
+# wrong constant name and_raise
+# wrong constant name and_return
+# wrong constant name and_throw
+# wrong constant name and_yield
+# wrong constant name description
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name name
+# wrong constant name setup_allowance
+# wrong constant name setup_any_instance_allowance
+# wrong constant name setup_any_instance_expectation
+# wrong constant name setup_expectation
+# wrong constant name setup_negative_expectation
+# wrong constant name with
+# wrong constant name <static-init>
+# wrong constant name description
+# wrong constant name does_not_match?
+# wrong constant name initialize
+# wrong constant name matches?
+# wrong constant name name
+# wrong constant name setup_allowance
+# wrong constant name setup_any_instance_allowance
+# wrong constant name setup_any_instance_expectation
+# wrong constant name setup_expectation
+# wrong constant name setup_negative_expectation
+# wrong constant name warn_about_block
+# wrong constant name <static-init>
+# wrong constant name block
+# wrong constant name chain
+# wrong constant name initialize
+# wrong constant name object
+# wrong constant name setup_chain
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name stub_chain_on
 # wrong constant name <Class:Differ>
 # wrong constant name color?
 # wrong constant name diff
@@ -4124,65 +4874,40 @@
 # wrong constant name diff_as_string
 # wrong constant name initialize
 # wrong constant name <static-init>
-# wrong constant name deregister_matcher_definition
-# wrong constant name is_a_matcher?
-# wrong constant name matcher_definitions
-# wrong constant name register_matcher_definition
-# wrong constant name rspec_description_for_object
 # uninitialized constant Racc
 # uninitialized constant Racc
 # wrong constant name <Class:TaskLib>
 # uninitialized constant Rake::DSL::DEFAULT
-# Did you mean?  Rake::DSL::DEFAULT
 # uninitialized constant Rake::DSL::LN_SUPPORTED
-# Did you mean?  Rake::DSL::LN_SUPPORTED
 # uninitialized constant Rake::DSL::LOW_METHODS
 # Did you mean?  Rake::DSL::LowMethods
-#                Rake::DSL::LOW_METHODS
 # uninitialized constant Rake::DSL::METHODS
 # Did you mean?  Method
-#                Rake::DSL::METHODS
 # uninitialized constant Rake::DSL::OPT_TABLE
-# Did you mean?  Rake::DSL::OPT_TABLE
 # uninitialized constant Rake::DSL::RUBY
-# Did you mean?  Rake::DSL::RUBY
 # uninitialized constant Rake::DSL::VERSION
 # Did you mean?  Rake::Version
-#                Rake::DSL::VERSION
 #                Rake::VERSION
 # uninitialized constant Rake::FileUtilsExt::LN_SUPPORTED
-# Did you mean?  Rake::FileUtilsExt::LN_SUPPORTED
 # uninitialized constant Rake::FileUtilsExt::LOW_METHODS
 # Did you mean?  Rake::FileUtilsExt::LowMethods
-#                Rake::FileUtilsExt::LOW_METHODS
 # uninitialized constant Rake::FileUtilsExt::METHODS
 # Did you mean?  Method
-#                Rake::FileUtilsExt::METHODS
 # uninitialized constant Rake::FileUtilsExt::OPT_TABLE
-# Did you mean?  Rake::FileUtilsExt::OPT_TABLE
 # uninitialized constant Rake::FileUtilsExt::RUBY
-# Did you mean?  Rake::FileUtilsExt::RUBY
 # uninitialized constant Rake::FileUtilsExt::VERSION
 # Did you mean?  Rake::Version
-#                Rake::FileUtilsExt::VERSION
 #                Rake::VERSION
 # uninitialized constant Rake::TaskLib::DEFAULT
-# Did you mean?  Rake::TaskLib::DEFAULT
 # uninitialized constant Rake::TaskLib::LN_SUPPORTED
-# Did you mean?  Rake::TaskLib::LN_SUPPORTED
 # uninitialized constant Rake::TaskLib::LOW_METHODS
 # Did you mean?  Rake::TaskLib::LowMethods
-#                Rake::TaskLib::LOW_METHODS
 # uninitialized constant Rake::TaskLib::METHODS
 # Did you mean?  Method
-#                Rake::TaskLib::METHODS
 # uninitialized constant Rake::TaskLib::OPT_TABLE
-# Did you mean?  Rake::TaskLib::OPT_TABLE
 # uninitialized constant Rake::TaskLib::RUBY
-# Did you mean?  Rake::TaskLib::RUBY
 # uninitialized constant Rake::TaskLib::VERSION
 # Did you mean?  Rake::Version
-#                Rake::TaskLib::VERSION
 #                Rake::VERSION
 # wrong constant name paste
 # wrong constant name <static-init>
@@ -4192,8 +4917,20 @@
 # wrong constant name alphanumeric
 # wrong constant name rand$2
 # wrong constant name random_number$2
+# wrong constant name bytes
 # wrong constant name urandom
+# undefined method `initialize$1' for class `Range'
+# Did you mean?  initialize
+# undefined method `last$2' for class `Range'
+# undefined method `step$2' for class `Range'
+# wrong constant name %
+# wrong constant name entries
+# wrong constant name initialize$1
+# wrong constant name last$2
+# wrong constant name step$2
+# wrong constant name to_a
 # wrong constant name expand
+# wrong constant name fire_update!
 # wrong constant name ruby
 # undefined method `initialize$2' for class `Regexp'
 # Did you mean?  initialize
@@ -4206,6 +4943,19 @@
 # wrong constant name compile$2
 # wrong constant name last_match$2
 # wrong constant name union
+# wrong constant name <Class:Node>
+# wrong constant name children
+# wrong constant name first_column
+# wrong constant name first_lineno
+# wrong constant name last_column
+# wrong constant name last_lineno
+# wrong constant name pretty_print_children
+# wrong constant name type
+# wrong constant name <static-init>
+# wrong constant name <static-init>
+# wrong constant name of
+# wrong constant name parse
+# wrong constant name parse_file
 # wrong constant name absolute_path
 # wrong constant name base_label
 # wrong constant name disasm
@@ -4227,6 +4977,11 @@
 # wrong constant name load_from_binary
 # wrong constant name load_from_binary_extra_data
 # wrong constant name of
+# wrong constant name <static-init>
+# wrong constant name enabled?
+# wrong constant name pause
+# wrong constant name resume
+# wrong constant name resolve_feature_path
 # wrong constant name stat
 # wrong constant name ==
 # wrong constant name ===
@@ -4234,6 +4989,7 @@
 # wrong constant name compare_by_identity?
 # wrong constant name divide
 # wrong constant name eql?
+# wrong constant name filter!
 # wrong constant name flatten_merge
 # wrong constant name pretty_print
 # wrong constant name pretty_print_cycle
@@ -4248,8 +5004,12 @@
 # wrong constant name split
 # wrong constant name signm
 # wrong constant name signo
-# uninitialized constant SingleForwardable
-# uninitialized constant SingleForwardable
+# wrong constant name def_delegator
+# wrong constant name def_delegators
+# wrong constant name def_single_delegator
+# wrong constant name def_single_delegators
+# wrong constant name delegate
+# wrong constant name single_delegate
 # wrong constant name _dump
 # wrong constant name clone
 # wrong constant name dup
@@ -4417,7 +5177,6 @@
 # wrong constant name output_file
 # wrong constant name <static-init>
 # uninitialized constant SortedSet::InspectKey
-# Did you mean?  SortedSet::InspectKey
 # wrong constant name initialize
 # wrong constant name setup
 # wrong constant name result
@@ -4602,6 +5361,7 @@
 # wrong constant name []=
 # wrong constant name dig
 # wrong constant name each_pair
+# wrong constant name filter
 # wrong constant name initialize$1
 # wrong constant name length
 # wrong constant name members
@@ -4724,7 +5484,14 @@
 # wrong constant name mktime$1
 # wrong constant name utc$1
 # wrong constant name zone_offset$1
+# undefined method `enable$2' for class `TracePoint'
+# wrong constant name __enable
+# wrong constant name enable$2
+# wrong constant name eval_script
 # wrong constant name event
+# wrong constant name instruction_sequence
+# wrong constant name parameters
+# wrong constant name <Class:File>
 # wrong constant name decode
 # wrong constant name encode
 # wrong constant name escape
@@ -4734,6 +5501,71 @@
 # wrong constant name typecode
 # wrong constant name typecode=
 # wrong constant name new2
+# uninitialized constant URI::File::ABS_PATH
+# Did you mean?  URI::ABS_PATH
+# uninitialized constant URI::File::ABS_URI
+# Did you mean?  URI::ABS_URI
+# uninitialized constant URI::File::ABS_URI_REF
+# Did you mean?  URI::ABS_URI_REF
+# uninitialized constant URI::File::DEFAULT_PARSER
+# Did you mean?  URI::File::DEFAULT_PORT
+#                URI::DEFAULT_PARSER
+# uninitialized constant URI::File::ESCAPED
+# Did you mean?  URI::File::Escape
+#                URI::Escape
+#                URI::ESCAPED
+# uninitialized constant URI::File::FRAGMENT
+# Did you mean?  URI::FRAGMENT
+# uninitialized constant URI::File::HOST
+# Did you mean?  URI::HOST
+# uninitialized constant URI::File::OPAQUE
+# Did you mean?  URI::OPAQUE
+# uninitialized constant URI::File::PORT
+# Did you mean?  URI::PORT
+# uninitialized constant URI::File::QUERY
+# Did you mean?  URI::QUERY
+# uninitialized constant URI::File::REGISTRY
+# Did you mean?  URI::REGISTRY
+# uninitialized constant URI::File::REL_PATH
+# Did you mean?  URI::REL_PATH
+# uninitialized constant URI::File::REL_URI
+# Did you mean?  URI::REL_URI
+# uninitialized constant URI::File::REL_URI_REF
+# Did you mean?  URI::REL_URI_REF
+# uninitialized constant URI::File::RFC3986_PARSER
+# Did you mean?  URI::File::RFC3986_Parser
+#                URI::RFC3986_Parser
+#                URI::RFC2396_Parser
+#                URI::File::RFC2396_Parser
+#                URI::RFC3986_PARSER
+# uninitialized constant URI::File::SCHEME
+# Did you mean?  URI::SCHEME
+# uninitialized constant URI::File::TBLDECWWWCOMP_
+# Did you mean?  URI::File::TBLENCWWWCOMP_
+#                URI::TBLDECWWWCOMP_
+#                URI::TBLENCWWWCOMP_
+# uninitialized constant URI::File::TBLENCWWWCOMP_
+# Did you mean?  URI::File::TBLDECWWWCOMP_
+#                URI::TBLDECWWWCOMP_
+#                URI::TBLENCWWWCOMP_
+# uninitialized constant URI::File::UNSAFE
+# Did you mean?  URI::UNSAFE
+# uninitialized constant URI::File::URI_REF
+# Did you mean?  URI::URI_REF
+# uninitialized constant URI::File::USERINFO
+# Did you mean?  URI::USERINFO
+# uninitialized constant URI::File::USE_REGISTRY
+# uninitialized constant URI::File::VERSION
+# Did you mean?  URI::VERSION
+# uninitialized constant URI::File::VERSION_CODE
+# Did you mean?  URI::VERSION_CODE
+# uninitialized constant URI::File::WEB_ENCODINGS_
+# Did you mean?  URI::WEB_ENCODINGS_
+# wrong constant name check_password
+# wrong constant name check_user
+# wrong constant name check_userinfo
+# wrong constant name set_userinfo
+# wrong constant name <static-init>
 # wrong constant name +
 # wrong constant name -
 # wrong constant name ==
@@ -4880,7 +5712,6 @@
 # wrong constant name run
 # wrong constant name <static-init>
 # uninitialized constant YARD::CLI::Display::DEFAULT_YARDOPTS_FILE
-# Did you mean?  YARD::CLI::Display::DEFAULT_YARDOPTS_FILE
 # wrong constant name format_objects
 # wrong constant name initialize
 # wrong constant name wrap_layout
@@ -4888,7 +5719,6 @@
 # wrong constant name run
 # wrong constant name <static-init>
 # uninitialized constant YARD::CLI::Graph::DEFAULT_YARDOPTS_FILE
-# Did you mean?  YARD::CLI::Graph::DEFAULT_YARDOPTS_FILE
 # wrong constant name objects
 # wrong constant name options
 # wrong constant name run
@@ -4896,7 +5726,6 @@
 # wrong constant name run
 # wrong constant name <static-init>
 # uninitialized constant YARD::CLI::I18n::DEFAULT_YARDOPTS_FILE
-# Did you mean?  YARD::CLI::I18n::DEFAULT_YARDOPTS_FILE
 # wrong constant name <static-init>
 # wrong constant name run
 # wrong constant name <static-init>
@@ -4917,7 +5746,6 @@
 # wrong constant name template_paths=
 # wrong constant name <static-init>
 # uninitialized constant YARD::CLI::Stats::DEFAULT_YARDOPTS_FILE
-# Did you mean?  YARD::CLI::Stats::DEFAULT_YARDOPTS_FILE
 # wrong constant name initialize
 # wrong constant name output
 # wrong constant name parse
@@ -5193,55 +6021,34 @@
 # wrong constant name each
 # wrong constant name find_all_by_name
 # uninitialized constant YARD::Handlers::Base::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Base::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Base::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Base::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Base::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Base::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Base::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Base::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Base::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Base::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Base::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Base::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Base::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Base::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Base::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Base::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Base::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Base::CSEP
 # Did you mean?  YARD::Handlers::Base::CSEPQ
-#                YARD::Handlers::Base::CSEP
 # uninitialized constant YARD::Handlers::Base::CSEPQ
-# Did you mean?  YARD::Handlers::Base::CSEPQ
-#                YARD::Handlers::Base::CSEP
-#                YARD::Handlers::Base::ISEPQ
+# Did you mean?  YARD::Handlers::Base::ISEPQ
 #                YARD::Handlers::Base::NSEPQ
 # uninitialized constant YARD::Handlers::Base::ISEP
 # Did you mean?  YARD::Handlers::Base::ISEPQ
-#                YARD::Handlers::Base::ISEP
 # uninitialized constant YARD::Handlers::Base::ISEPQ
 # Did you mean?  YARD::Handlers::Base::CSEPQ
-#                YARD::Handlers::Base::ISEPQ
-#                YARD::Handlers::Base::ISEP
 #                YARD::Handlers::Base::NSEPQ
 # uninitialized constant YARD::Handlers::Base::METHODMATCH
-# Did you mean?  YARD::Handlers::Base::METHODMATCH
 # uninitialized constant YARD::Handlers::Base::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Base::METHODNAMEMATCH
-#                YARD::Handlers::Base::METHODMATCH
+# Did you mean?  YARD::Handlers::Base::METHODMATCH
 # uninitialized constant YARD::Handlers::Base::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Base::NamespaceMapper
-#                YARD::Handlers::Base::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Base::NSEP
 # Did you mean?  YARD::Handlers::Base::NSEPQ
-#                YARD::Handlers::Base::NSEP
 # uninitialized constant YARD::Handlers::Base::NSEPQ
 # Did you mean?  YARD::Handlers::Base::CSEPQ
 #                YARD::Handlers::Base::ISEPQ
-#                YARD::Handlers::Base::NSEPQ
-#                YARD::Handlers::Base::NSEP
 # uninitialized constant YARD::Handlers::Base::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Base::PROXY_MATCH
 # wrong constant name abort!
 # wrong constant name call_params
 # wrong constant name caller_method
@@ -5285,157 +6092,94 @@
 # wrong constant name process
 # wrong constant name subclasses
 # uninitialized constant YARD::Handlers::C::AliasHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::C::AliasHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::C::AliasHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::C::AliasHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::C::AliasHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::C::AliasHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::C::AliasHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::C::AliasHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::C::AliasHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::C::AliasHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::C::AliasHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::C::AliasHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::C::AliasHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::C::AliasHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::C::AliasHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::C::AliasHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::C::AliasHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::C::AliasHandler::CSEP
 # Did you mean?  YARD::Handlers::C::AliasHandler::CSEPQ
-#                YARD::Handlers::C::AliasHandler::CSEP
 # uninitialized constant YARD::Handlers::C::AliasHandler::CSEPQ
-# Did you mean?  YARD::Handlers::C::AliasHandler::CSEPQ
-#                YARD::Handlers::C::AliasHandler::CSEP
-#                YARD::Handlers::C::AliasHandler::ISEPQ
+# Did you mean?  YARD::Handlers::C::AliasHandler::ISEPQ
 #                YARD::Handlers::C::AliasHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::AliasHandler::ISEP
 # Did you mean?  YARD::Handlers::C::AliasHandler::ISEPQ
-#                YARD::Handlers::C::AliasHandler::ISEP
 # uninitialized constant YARD::Handlers::C::AliasHandler::ISEPQ
 # Did you mean?  YARD::Handlers::C::AliasHandler::CSEPQ
-#                YARD::Handlers::C::AliasHandler::ISEPQ
-#                YARD::Handlers::C::AliasHandler::ISEP
 #                YARD::Handlers::C::AliasHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::AliasHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::C::AliasHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::AliasHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::C::AliasHandler::METHODNAMEMATCH
-#                YARD::Handlers::C::AliasHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::C::AliasHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::AliasHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::C::AliasHandler::NamespaceMapper
-#                YARD::Handlers::C::AliasHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::C::AliasHandler::NSEP
 # Did you mean?  YARD::Handlers::C::AliasHandler::NSEPQ
-#                YARD::Handlers::C::AliasHandler::NSEP
 # uninitialized constant YARD::Handlers::C::AliasHandler::NSEPQ
 # Did you mean?  YARD::Handlers::C::AliasHandler::CSEPQ
 #                YARD::Handlers::C::AliasHandler::ISEPQ
-#                YARD::Handlers::C::AliasHandler::NSEPQ
-#                YARD::Handlers::C::AliasHandler::NSEP
 # uninitialized constant YARD::Handlers::C::AliasHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::C::AliasHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::C::AttributeHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::C::AttributeHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::C::AttributeHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::C::AttributeHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::C::AttributeHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::C::AttributeHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::C::AttributeHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::C::AttributeHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::C::AttributeHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::C::AttributeHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::C::AttributeHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::C::AttributeHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::C::AttributeHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::C::AttributeHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::C::AttributeHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::C::AttributeHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::C::AttributeHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::C::AttributeHandler::CSEP
 # Did you mean?  YARD::Handlers::C::AttributeHandler::CSEPQ
-#                YARD::Handlers::C::AttributeHandler::CSEP
 # uninitialized constant YARD::Handlers::C::AttributeHandler::CSEPQ
-# Did you mean?  YARD::Handlers::C::AttributeHandler::CSEPQ
-#                YARD::Handlers::C::AttributeHandler::CSEP
-#                YARD::Handlers::C::AttributeHandler::ISEPQ
+# Did you mean?  YARD::Handlers::C::AttributeHandler::ISEPQ
 #                YARD::Handlers::C::AttributeHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::AttributeHandler::ISEP
 # Did you mean?  YARD::Handlers::C::AttributeHandler::ISEPQ
-#                YARD::Handlers::C::AttributeHandler::ISEP
 # uninitialized constant YARD::Handlers::C::AttributeHandler::ISEPQ
 # Did you mean?  YARD::Handlers::C::AttributeHandler::CSEPQ
-#                YARD::Handlers::C::AttributeHandler::ISEPQ
-#                YARD::Handlers::C::AttributeHandler::ISEP
 #                YARD::Handlers::C::AttributeHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::AttributeHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::C::AttributeHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::AttributeHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::C::AttributeHandler::METHODNAMEMATCH
-#                YARD::Handlers::C::AttributeHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::C::AttributeHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::AttributeHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::C::AttributeHandler::NamespaceMapper
-#                YARD::Handlers::C::AttributeHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::C::AttributeHandler::NSEP
 # Did you mean?  YARD::Handlers::C::AttributeHandler::NSEPQ
-#                YARD::Handlers::C::AttributeHandler::NSEP
 # uninitialized constant YARD::Handlers::C::AttributeHandler::NSEPQ
 # Did you mean?  YARD::Handlers::C::AttributeHandler::CSEPQ
 #                YARD::Handlers::C::AttributeHandler::ISEPQ
-#                YARD::Handlers::C::AttributeHandler::NSEPQ
-#                YARD::Handlers::C::AttributeHandler::NSEP
 # uninitialized constant YARD::Handlers::C::AttributeHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::C::AttributeHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::C::Base::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::C::Base::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::C::Base::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::C::Base::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::C::Base::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::C::Base::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::C::Base::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::C::Base::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::C::Base::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::C::Base::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::C::Base::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::C::Base::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::C::Base::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::C::Base::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::C::Base::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::C::Base::CONSTANTSTART
-# Did you mean?  YARD::Handlers::C::Base::CONSTANTSTART
 # uninitialized constant YARD::Handlers::C::Base::CSEP
 # Did you mean?  YARD::Handlers::C::Base::CSEPQ
-#                YARD::Handlers::C::Base::CSEP
 # uninitialized constant YARD::Handlers::C::Base::CSEPQ
-# Did you mean?  YARD::Handlers::C::Base::CSEPQ
-#                YARD::Handlers::C::Base::CSEP
-#                YARD::Handlers::C::Base::ISEPQ
+# Did you mean?  YARD::Handlers::C::Base::ISEPQ
 #                YARD::Handlers::C::Base::NSEPQ
 # uninitialized constant YARD::Handlers::C::Base::ISEP
 # Did you mean?  YARD::Handlers::C::Base::ISEPQ
-#                YARD::Handlers::C::Base::ISEP
 # uninitialized constant YARD::Handlers::C::Base::ISEPQ
 # Did you mean?  YARD::Handlers::C::Base::CSEPQ
-#                YARD::Handlers::C::Base::ISEPQ
-#                YARD::Handlers::C::Base::ISEP
 #                YARD::Handlers::C::Base::NSEPQ
 # uninitialized constant YARD::Handlers::C::Base::METHODMATCH
-# Did you mean?  YARD::Handlers::C::Base::METHODMATCH
 # uninitialized constant YARD::Handlers::C::Base::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::C::Base::METHODNAMEMATCH
-#                YARD::Handlers::C::Base::METHODMATCH
+# Did you mean?  YARD::Handlers::C::Base::METHODMATCH
 # uninitialized constant YARD::Handlers::C::Base::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::C::Base::NamespaceMapper
-#                YARD::Handlers::C::Base::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::C::Base::NSEP
 # Did you mean?  YARD::Handlers::C::Base::NSEPQ
-#                YARD::Handlers::C::Base::NSEP
 # uninitialized constant YARD::Handlers::C::Base::NSEPQ
 # Did you mean?  YARD::Handlers::C::Base::CSEPQ
 #                YARD::Handlers::C::Base::ISEPQ
-#                YARD::Handlers::C::Base::NSEPQ
-#                YARD::Handlers::C::Base::NSEP
 # uninitialized constant YARD::Handlers::C::Base::PROXY_MATCH
-# Did you mean?  YARD::Handlers::C::Base::PROXY_MATCH
 # wrong constant name ensure_variable_defined!
 # wrong constant name namespace_for_variable
 # wrong constant name namespaces
@@ -5448,157 +6192,94 @@
 # wrong constant name handles?
 # wrong constant name statement_class
 # uninitialized constant YARD::Handlers::C::ClassHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::C::ClassHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::C::ClassHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::C::ClassHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::C::ClassHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::C::ClassHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::C::ClassHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::C::ClassHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::C::ClassHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::C::ClassHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::C::ClassHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::C::ClassHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::C::ClassHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::C::ClassHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::C::ClassHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::C::ClassHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::C::ClassHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::C::ClassHandler::CSEP
 # Did you mean?  YARD::Handlers::C::ClassHandler::CSEPQ
-#                YARD::Handlers::C::ClassHandler::CSEP
 # uninitialized constant YARD::Handlers::C::ClassHandler::CSEPQ
-# Did you mean?  YARD::Handlers::C::ClassHandler::CSEPQ
-#                YARD::Handlers::C::ClassHandler::CSEP
-#                YARD::Handlers::C::ClassHandler::ISEPQ
+# Did you mean?  YARD::Handlers::C::ClassHandler::ISEPQ
 #                YARD::Handlers::C::ClassHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::ClassHandler::ISEP
 # Did you mean?  YARD::Handlers::C::ClassHandler::ISEPQ
-#                YARD::Handlers::C::ClassHandler::ISEP
 # uninitialized constant YARD::Handlers::C::ClassHandler::ISEPQ
 # Did you mean?  YARD::Handlers::C::ClassHandler::CSEPQ
-#                YARD::Handlers::C::ClassHandler::ISEPQ
-#                YARD::Handlers::C::ClassHandler::ISEP
 #                YARD::Handlers::C::ClassHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::ClassHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::C::ClassHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::ClassHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::C::ClassHandler::METHODNAMEMATCH
-#                YARD::Handlers::C::ClassHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::C::ClassHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::ClassHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::C::ClassHandler::NamespaceMapper
-#                YARD::Handlers::C::ClassHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::C::ClassHandler::NSEP
 # Did you mean?  YARD::Handlers::C::ClassHandler::NSEPQ
-#                YARD::Handlers::C::ClassHandler::NSEP
 # uninitialized constant YARD::Handlers::C::ClassHandler::NSEPQ
 # Did you mean?  YARD::Handlers::C::ClassHandler::CSEPQ
 #                YARD::Handlers::C::ClassHandler::ISEPQ
-#                YARD::Handlers::C::ClassHandler::NSEPQ
-#                YARD::Handlers::C::ClassHandler::NSEP
 # uninitialized constant YARD::Handlers::C::ClassHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::C::ClassHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::C::ConstantHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::C::ConstantHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::C::ConstantHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::C::ConstantHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::C::ConstantHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::C::ConstantHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::C::ConstantHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::C::ConstantHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::C::ConstantHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::C::ConstantHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::C::ConstantHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::C::ConstantHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::C::ConstantHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::C::ConstantHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::C::ConstantHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::C::ConstantHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::C::ConstantHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::C::ConstantHandler::CSEP
 # Did you mean?  YARD::Handlers::C::ConstantHandler::CSEPQ
-#                YARD::Handlers::C::ConstantHandler::CSEP
 # uninitialized constant YARD::Handlers::C::ConstantHandler::CSEPQ
-# Did you mean?  YARD::Handlers::C::ConstantHandler::CSEPQ
-#                YARD::Handlers::C::ConstantHandler::CSEP
-#                YARD::Handlers::C::ConstantHandler::ISEPQ
+# Did you mean?  YARD::Handlers::C::ConstantHandler::ISEPQ
 #                YARD::Handlers::C::ConstantHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::ConstantHandler::ISEP
 # Did you mean?  YARD::Handlers::C::ConstantHandler::ISEPQ
-#                YARD::Handlers::C::ConstantHandler::ISEP
 # uninitialized constant YARD::Handlers::C::ConstantHandler::ISEPQ
 # Did you mean?  YARD::Handlers::C::ConstantHandler::CSEPQ
-#                YARD::Handlers::C::ConstantHandler::ISEPQ
-#                YARD::Handlers::C::ConstantHandler::ISEP
 #                YARD::Handlers::C::ConstantHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::ConstantHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::C::ConstantHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::ConstantHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::C::ConstantHandler::METHODNAMEMATCH
-#                YARD::Handlers::C::ConstantHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::C::ConstantHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::ConstantHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::C::ConstantHandler::NamespaceMapper
-#                YARD::Handlers::C::ConstantHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::C::ConstantHandler::NSEP
 # Did you mean?  YARD::Handlers::C::ConstantHandler::NSEPQ
-#                YARD::Handlers::C::ConstantHandler::NSEP
 # uninitialized constant YARD::Handlers::C::ConstantHandler::NSEPQ
 # Did you mean?  YARD::Handlers::C::ConstantHandler::CSEPQ
 #                YARD::Handlers::C::ConstantHandler::ISEPQ
-#                YARD::Handlers::C::ConstantHandler::NSEPQ
-#                YARD::Handlers::C::ConstantHandler::NSEP
 # uninitialized constant YARD::Handlers::C::ConstantHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::C::ConstantHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::C::HandlerMethods::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::C::HandlerMethods::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::C::HandlerMethods::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::C::HandlerMethods::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::C::HandlerMethods::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::C::HandlerMethods::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::C::HandlerMethods::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::C::HandlerMethods::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::C::HandlerMethods::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::C::HandlerMethods::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::C::HandlerMethods::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::C::HandlerMethods::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::C::HandlerMethods::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::C::HandlerMethods::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::C::HandlerMethods::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::C::HandlerMethods::CONSTANTSTART
-# Did you mean?  YARD::Handlers::C::HandlerMethods::CONSTANTSTART
 # uninitialized constant YARD::Handlers::C::HandlerMethods::CSEP
 # Did you mean?  YARD::Handlers::C::HandlerMethods::CSEPQ
-#                YARD::Handlers::C::HandlerMethods::CSEP
 # uninitialized constant YARD::Handlers::C::HandlerMethods::CSEPQ
-# Did you mean?  YARD::Handlers::C::HandlerMethods::CSEPQ
-#                YARD::Handlers::C::HandlerMethods::CSEP
-#                YARD::Handlers::C::HandlerMethods::ISEPQ
+# Did you mean?  YARD::Handlers::C::HandlerMethods::ISEPQ
 #                YARD::Handlers::C::HandlerMethods::NSEPQ
 # uninitialized constant YARD::Handlers::C::HandlerMethods::ISEP
 # Did you mean?  YARD::Handlers::C::HandlerMethods::ISEPQ
-#                YARD::Handlers::C::HandlerMethods::ISEP
 # uninitialized constant YARD::Handlers::C::HandlerMethods::ISEPQ
 # Did you mean?  YARD::Handlers::C::HandlerMethods::CSEPQ
-#                YARD::Handlers::C::HandlerMethods::ISEPQ
-#                YARD::Handlers::C::HandlerMethods::ISEP
 #                YARD::Handlers::C::HandlerMethods::NSEPQ
 # uninitialized constant YARD::Handlers::C::HandlerMethods::METHODMATCH
-# Did you mean?  YARD::Handlers::C::HandlerMethods::METHODMATCH
 # uninitialized constant YARD::Handlers::C::HandlerMethods::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::C::HandlerMethods::METHODNAMEMATCH
-#                YARD::Handlers::C::HandlerMethods::METHODMATCH
+# Did you mean?  YARD::Handlers::C::HandlerMethods::METHODMATCH
 # uninitialized constant YARD::Handlers::C::HandlerMethods::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::C::HandlerMethods::NamespaceMapper
-#                YARD::Handlers::C::HandlerMethods::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::C::HandlerMethods::NSEP
 # Did you mean?  YARD::Handlers::C::HandlerMethods::NSEPQ
-#                YARD::Handlers::C::HandlerMethods::NSEP
 # uninitialized constant YARD::Handlers::C::HandlerMethods::NSEPQ
 # Did you mean?  YARD::Handlers::C::HandlerMethods::CSEPQ
 #                YARD::Handlers::C::HandlerMethods::ISEPQ
-#                YARD::Handlers::C::HandlerMethods::NSEPQ
-#                YARD::Handlers::C::HandlerMethods::NSEP
 # uninitialized constant YARD::Handlers::C::HandlerMethods::PROXY_MATCH
-# Did you mean?  YARD::Handlers::C::HandlerMethods::PROXY_MATCH
 # wrong constant name handle_alias
 # wrong constant name handle_attribute
 # wrong constant name handle_class
@@ -5607,412 +6288,244 @@
 # wrong constant name handle_module
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::C::InitHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::C::InitHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::C::InitHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::C::InitHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::C::InitHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::C::InitHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::C::InitHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::C::InitHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::C::InitHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::C::InitHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::C::InitHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::C::InitHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::C::InitHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::C::InitHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::C::InitHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::C::InitHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::C::InitHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::C::InitHandler::CSEP
 # Did you mean?  YARD::Handlers::C::InitHandler::CSEPQ
-#                YARD::Handlers::C::InitHandler::CSEP
 # uninitialized constant YARD::Handlers::C::InitHandler::CSEPQ
-# Did you mean?  YARD::Handlers::C::InitHandler::CSEPQ
-#                YARD::Handlers::C::InitHandler::CSEP
-#                YARD::Handlers::C::InitHandler::ISEPQ
+# Did you mean?  YARD::Handlers::C::InitHandler::ISEPQ
 #                YARD::Handlers::C::InitHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::InitHandler::ISEP
 # Did you mean?  YARD::Handlers::C::InitHandler::ISEPQ
-#                YARD::Handlers::C::InitHandler::ISEP
 # uninitialized constant YARD::Handlers::C::InitHandler::ISEPQ
 # Did you mean?  YARD::Handlers::C::InitHandler::CSEPQ
-#                YARD::Handlers::C::InitHandler::ISEPQ
-#                YARD::Handlers::C::InitHandler::ISEP
 #                YARD::Handlers::C::InitHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::InitHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::C::InitHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::InitHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::C::InitHandler::METHODNAMEMATCH
-#                YARD::Handlers::C::InitHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::C::InitHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::InitHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::C::InitHandler::NamespaceMapper
-#                YARD::Handlers::C::InitHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::C::InitHandler::NSEP
 # Did you mean?  YARD::Handlers::C::InitHandler::NSEPQ
-#                YARD::Handlers::C::InitHandler::NSEP
 # uninitialized constant YARD::Handlers::C::InitHandler::NSEPQ
 # Did you mean?  YARD::Handlers::C::InitHandler::CSEPQ
 #                YARD::Handlers::C::InitHandler::ISEPQ
-#                YARD::Handlers::C::InitHandler::NSEPQ
-#                YARD::Handlers::C::InitHandler::NSEP
 # uninitialized constant YARD::Handlers::C::InitHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::C::InitHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::C::MethodHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::C::MethodHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::C::MethodHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::C::MethodHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::C::MethodHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::C::MethodHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::C::MethodHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::C::MethodHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::C::MethodHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::C::MethodHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::C::MethodHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::C::MethodHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::C::MethodHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::C::MethodHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::C::MethodHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::C::MethodHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::C::MethodHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::C::MethodHandler::CSEP
 # Did you mean?  YARD::Handlers::C::MethodHandler::CSEPQ
-#                YARD::Handlers::C::MethodHandler::CSEP
 # uninitialized constant YARD::Handlers::C::MethodHandler::CSEPQ
-# Did you mean?  YARD::Handlers::C::MethodHandler::CSEPQ
-#                YARD::Handlers::C::MethodHandler::CSEP
-#                YARD::Handlers::C::MethodHandler::ISEPQ
+# Did you mean?  YARD::Handlers::C::MethodHandler::ISEPQ
 #                YARD::Handlers::C::MethodHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::MethodHandler::ISEP
 # Did you mean?  YARD::Handlers::C::MethodHandler::ISEPQ
-#                YARD::Handlers::C::MethodHandler::ISEP
 # uninitialized constant YARD::Handlers::C::MethodHandler::ISEPQ
 # Did you mean?  YARD::Handlers::C::MethodHandler::CSEPQ
-#                YARD::Handlers::C::MethodHandler::ISEPQ
-#                YARD::Handlers::C::MethodHandler::ISEP
 #                YARD::Handlers::C::MethodHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::MethodHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::C::MethodHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::MethodHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::C::MethodHandler::METHODNAMEMATCH
-#                YARD::Handlers::C::MethodHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::C::MethodHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::MethodHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::C::MethodHandler::NamespaceMapper
-#                YARD::Handlers::C::MethodHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::C::MethodHandler::NSEP
 # Did you mean?  YARD::Handlers::C::MethodHandler::NSEPQ
-#                YARD::Handlers::C::MethodHandler::NSEP
 # uninitialized constant YARD::Handlers::C::MethodHandler::NSEPQ
 # Did you mean?  YARD::Handlers::C::MethodHandler::CSEPQ
 #                YARD::Handlers::C::MethodHandler::ISEPQ
-#                YARD::Handlers::C::MethodHandler::NSEPQ
-#                YARD::Handlers::C::MethodHandler::NSEP
 # uninitialized constant YARD::Handlers::C::MethodHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::C::MethodHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::C::MixinHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::C::MixinHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::C::MixinHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::C::MixinHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::C::MixinHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::C::MixinHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::C::MixinHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::C::MixinHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::C::MixinHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::C::MixinHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::C::MixinHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::C::MixinHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::C::MixinHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::C::MixinHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::C::MixinHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::C::MixinHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::C::MixinHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::C::MixinHandler::CSEP
 # Did you mean?  YARD::Handlers::C::MixinHandler::CSEPQ
-#                YARD::Handlers::C::MixinHandler::CSEP
 # uninitialized constant YARD::Handlers::C::MixinHandler::CSEPQ
-# Did you mean?  YARD::Handlers::C::MixinHandler::CSEPQ
-#                YARD::Handlers::C::MixinHandler::CSEP
-#                YARD::Handlers::C::MixinHandler::ISEPQ
+# Did you mean?  YARD::Handlers::C::MixinHandler::ISEPQ
 #                YARD::Handlers::C::MixinHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::MixinHandler::ISEP
 # Did you mean?  YARD::Handlers::C::MixinHandler::ISEPQ
-#                YARD::Handlers::C::MixinHandler::ISEP
 # uninitialized constant YARD::Handlers::C::MixinHandler::ISEPQ
 # Did you mean?  YARD::Handlers::C::MixinHandler::CSEPQ
-#                YARD::Handlers::C::MixinHandler::ISEPQ
-#                YARD::Handlers::C::MixinHandler::ISEP
 #                YARD::Handlers::C::MixinHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::MixinHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::C::MixinHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::MixinHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::C::MixinHandler::METHODNAMEMATCH
-#                YARD::Handlers::C::MixinHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::C::MixinHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::MixinHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::C::MixinHandler::NamespaceMapper
-#                YARD::Handlers::C::MixinHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::C::MixinHandler::NSEP
 # Did you mean?  YARD::Handlers::C::MixinHandler::NSEPQ
-#                YARD::Handlers::C::MixinHandler::NSEP
 # uninitialized constant YARD::Handlers::C::MixinHandler::NSEPQ
 # Did you mean?  YARD::Handlers::C::MixinHandler::CSEPQ
 #                YARD::Handlers::C::MixinHandler::ISEPQ
-#                YARD::Handlers::C::MixinHandler::NSEPQ
-#                YARD::Handlers::C::MixinHandler::NSEP
 # uninitialized constant YARD::Handlers::C::MixinHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::C::MixinHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::C::ModuleHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::C::ModuleHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::C::ModuleHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::C::ModuleHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::C::ModuleHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::C::ModuleHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::C::ModuleHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::C::ModuleHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::C::ModuleHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::C::ModuleHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::C::ModuleHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::C::ModuleHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::C::ModuleHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::C::ModuleHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::C::ModuleHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::C::ModuleHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::C::ModuleHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::C::ModuleHandler::CSEP
 # Did you mean?  YARD::Handlers::C::ModuleHandler::CSEPQ
-#                YARD::Handlers::C::ModuleHandler::CSEP
 # uninitialized constant YARD::Handlers::C::ModuleHandler::CSEPQ
-# Did you mean?  YARD::Handlers::C::ModuleHandler::CSEPQ
-#                YARD::Handlers::C::ModuleHandler::CSEP
-#                YARD::Handlers::C::ModuleHandler::ISEPQ
+# Did you mean?  YARD::Handlers::C::ModuleHandler::ISEPQ
 #                YARD::Handlers::C::ModuleHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::ModuleHandler::ISEP
 # Did you mean?  YARD::Handlers::C::ModuleHandler::ISEPQ
-#                YARD::Handlers::C::ModuleHandler::ISEP
 # uninitialized constant YARD::Handlers::C::ModuleHandler::ISEPQ
 # Did you mean?  YARD::Handlers::C::ModuleHandler::CSEPQ
-#                YARD::Handlers::C::ModuleHandler::ISEPQ
-#                YARD::Handlers::C::ModuleHandler::ISEP
 #                YARD::Handlers::C::ModuleHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::ModuleHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::C::ModuleHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::ModuleHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::C::ModuleHandler::METHODNAMEMATCH
-#                YARD::Handlers::C::ModuleHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::C::ModuleHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::ModuleHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::C::ModuleHandler::NamespaceMapper
-#                YARD::Handlers::C::ModuleHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::C::ModuleHandler::NSEP
 # Did you mean?  YARD::Handlers::C::ModuleHandler::NSEPQ
-#                YARD::Handlers::C::ModuleHandler::NSEP
 # uninitialized constant YARD::Handlers::C::ModuleHandler::NSEPQ
 # Did you mean?  YARD::Handlers::C::ModuleHandler::CSEPQ
 #                YARD::Handlers::C::ModuleHandler::ISEPQ
-#                YARD::Handlers::C::ModuleHandler::NSEPQ
-#                YARD::Handlers::C::ModuleHandler::NSEP
 # uninitialized constant YARD::Handlers::C::ModuleHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::C::ModuleHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::C::OverrideCommentHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::C::OverrideCommentHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::C::OverrideCommentHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::C::OverrideCommentHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::C::OverrideCommentHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::C::OverrideCommentHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::C::OverrideCommentHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::C::OverrideCommentHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::C::OverrideCommentHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::C::OverrideCommentHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::C::OverrideCommentHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::CSEP
 # Did you mean?  YARD::Handlers::C::OverrideCommentHandler::CSEPQ
-#                YARD::Handlers::C::OverrideCommentHandler::CSEP
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::CSEPQ
-# Did you mean?  YARD::Handlers::C::OverrideCommentHandler::CSEPQ
-#                YARD::Handlers::C::OverrideCommentHandler::CSEP
-#                YARD::Handlers::C::OverrideCommentHandler::ISEPQ
+# Did you mean?  YARD::Handlers::C::OverrideCommentHandler::ISEPQ
 #                YARD::Handlers::C::OverrideCommentHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::ISEP
 # Did you mean?  YARD::Handlers::C::OverrideCommentHandler::ISEPQ
-#                YARD::Handlers::C::OverrideCommentHandler::ISEP
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::ISEPQ
 # Did you mean?  YARD::Handlers::C::OverrideCommentHandler::CSEPQ
-#                YARD::Handlers::C::OverrideCommentHandler::ISEPQ
-#                YARD::Handlers::C::OverrideCommentHandler::ISEP
 #                YARD::Handlers::C::OverrideCommentHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::C::OverrideCommentHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::C::OverrideCommentHandler::METHODNAMEMATCH
-#                YARD::Handlers::C::OverrideCommentHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::C::OverrideCommentHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::C::OverrideCommentHandler::NamespaceMapper
-#                YARD::Handlers::C::OverrideCommentHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::NSEP
 # Did you mean?  YARD::Handlers::C::OverrideCommentHandler::NSEPQ
-#                YARD::Handlers::C::OverrideCommentHandler::NSEP
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::NSEPQ
 # Did you mean?  YARD::Handlers::C::OverrideCommentHandler::CSEPQ
 #                YARD::Handlers::C::OverrideCommentHandler::ISEPQ
-#                YARD::Handlers::C::OverrideCommentHandler::NSEPQ
-#                YARD::Handlers::C::OverrideCommentHandler::NSEP
 # uninitialized constant YARD::Handlers::C::OverrideCommentHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::C::OverrideCommentHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::C::PathHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::C::PathHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::C::PathHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::C::PathHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::C::PathHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::C::PathHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::C::PathHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::C::PathHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::C::PathHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::C::PathHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::C::PathHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::C::PathHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::C::PathHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::C::PathHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::C::PathHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::C::PathHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::C::PathHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::C::PathHandler::CSEP
 # Did you mean?  YARD::Handlers::C::PathHandler::CSEPQ
-#                YARD::Handlers::C::PathHandler::CSEP
 # uninitialized constant YARD::Handlers::C::PathHandler::CSEPQ
-# Did you mean?  YARD::Handlers::C::PathHandler::CSEPQ
-#                YARD::Handlers::C::PathHandler::CSEP
-#                YARD::Handlers::C::PathHandler::ISEPQ
+# Did you mean?  YARD::Handlers::C::PathHandler::ISEPQ
 #                YARD::Handlers::C::PathHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::PathHandler::ISEP
 # Did you mean?  YARD::Handlers::C::PathHandler::ISEPQ
-#                YARD::Handlers::C::PathHandler::ISEP
 # uninitialized constant YARD::Handlers::C::PathHandler::ISEPQ
 # Did you mean?  YARD::Handlers::C::PathHandler::CSEPQ
-#                YARD::Handlers::C::PathHandler::ISEPQ
-#                YARD::Handlers::C::PathHandler::ISEP
 #                YARD::Handlers::C::PathHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::PathHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::C::PathHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::PathHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::C::PathHandler::METHODNAMEMATCH
-#                YARD::Handlers::C::PathHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::C::PathHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::PathHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::C::PathHandler::NamespaceMapper
-#                YARD::Handlers::C::PathHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::C::PathHandler::NSEP
 # Did you mean?  YARD::Handlers::C::PathHandler::NSEPQ
-#                YARD::Handlers::C::PathHandler::NSEP
 # uninitialized constant YARD::Handlers::C::PathHandler::NSEPQ
 # Did you mean?  YARD::Handlers::C::PathHandler::CSEPQ
 #                YARD::Handlers::C::PathHandler::ISEPQ
-#                YARD::Handlers::C::PathHandler::NSEPQ
-#                YARD::Handlers::C::PathHandler::NSEP
 # uninitialized constant YARD::Handlers::C::PathHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::C::PathHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::C::StructHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::C::StructHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::C::StructHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::C::StructHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::C::StructHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::C::StructHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::C::StructHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::C::StructHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::C::StructHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::C::StructHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::C::StructHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::C::StructHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::C::StructHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::C::StructHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::C::StructHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::C::StructHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::C::StructHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::C::StructHandler::CSEP
 # Did you mean?  YARD::Handlers::C::StructHandler::CSEPQ
-#                YARD::Handlers::C::StructHandler::CSEP
 # uninitialized constant YARD::Handlers::C::StructHandler::CSEPQ
-# Did you mean?  YARD::Handlers::C::StructHandler::CSEPQ
-#                YARD::Handlers::C::StructHandler::CSEP
-#                YARD::Handlers::C::StructHandler::ISEPQ
+# Did you mean?  YARD::Handlers::C::StructHandler::ISEPQ
 #                YARD::Handlers::C::StructHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::StructHandler::ISEP
 # Did you mean?  YARD::Handlers::C::StructHandler::ISEPQ
-#                YARD::Handlers::C::StructHandler::ISEP
 # uninitialized constant YARD::Handlers::C::StructHandler::ISEPQ
 # Did you mean?  YARD::Handlers::C::StructHandler::CSEPQ
-#                YARD::Handlers::C::StructHandler::ISEPQ
-#                YARD::Handlers::C::StructHandler::ISEP
 #                YARD::Handlers::C::StructHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::StructHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::C::StructHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::StructHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::C::StructHandler::METHODNAMEMATCH
-#                YARD::Handlers::C::StructHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::C::StructHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::StructHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::C::StructHandler::NamespaceMapper
-#                YARD::Handlers::C::StructHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::C::StructHandler::NSEP
 # Did you mean?  YARD::Handlers::C::StructHandler::NSEPQ
-#                YARD::Handlers::C::StructHandler::NSEP
 # uninitialized constant YARD::Handlers::C::StructHandler::NSEPQ
 # Did you mean?  YARD::Handlers::C::StructHandler::CSEPQ
 #                YARD::Handlers::C::StructHandler::ISEPQ
-#                YARD::Handlers::C::StructHandler::NSEPQ
-#                YARD::Handlers::C::StructHandler::NSEP
 # uninitialized constant YARD::Handlers::C::StructHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::C::StructHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::C::SymbolHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::C::SymbolHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::C::SymbolHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::C::SymbolHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::C::SymbolHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::C::SymbolHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::C::SymbolHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::C::SymbolHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::C::SymbolHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::C::SymbolHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::C::SymbolHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::C::SymbolHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::C::SymbolHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::C::SymbolHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::C::SymbolHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::C::SymbolHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::C::SymbolHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::C::SymbolHandler::CSEP
 # Did you mean?  YARD::Handlers::C::SymbolHandler::CSEPQ
-#                YARD::Handlers::C::SymbolHandler::CSEP
 # uninitialized constant YARD::Handlers::C::SymbolHandler::CSEPQ
-# Did you mean?  YARD::Handlers::C::SymbolHandler::CSEPQ
-#                YARD::Handlers::C::SymbolHandler::CSEP
-#                YARD::Handlers::C::SymbolHandler::ISEPQ
+# Did you mean?  YARD::Handlers::C::SymbolHandler::ISEPQ
 #                YARD::Handlers::C::SymbolHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::SymbolHandler::ISEP
 # Did you mean?  YARD::Handlers::C::SymbolHandler::ISEPQ
-#                YARD::Handlers::C::SymbolHandler::ISEP
 # uninitialized constant YARD::Handlers::C::SymbolHandler::ISEPQ
 # Did you mean?  YARD::Handlers::C::SymbolHandler::CSEPQ
-#                YARD::Handlers::C::SymbolHandler::ISEPQ
-#                YARD::Handlers::C::SymbolHandler::ISEP
 #                YARD::Handlers::C::SymbolHandler::NSEPQ
 # uninitialized constant YARD::Handlers::C::SymbolHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::C::SymbolHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::SymbolHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::C::SymbolHandler::METHODNAMEMATCH
-#                YARD::Handlers::C::SymbolHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::C::SymbolHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::C::SymbolHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::C::SymbolHandler::NamespaceMapper
-#                YARD::Handlers::C::SymbolHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::C::SymbolHandler::NSEP
 # Did you mean?  YARD::Handlers::C::SymbolHandler::NSEPQ
-#                YARD::Handlers::C::SymbolHandler::NSEP
 # uninitialized constant YARD::Handlers::C::SymbolHandler::NSEPQ
 # Did you mean?  YARD::Handlers::C::SymbolHandler::CSEPQ
 #                YARD::Handlers::C::SymbolHandler::ISEPQ
-#                YARD::Handlers::C::SymbolHandler::NSEPQ
-#                YARD::Handlers::C::SymbolHandler::NSEP
 # uninitialized constant YARD::Handlers::C::SymbolHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::C::SymbolHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # wrong constant name add_predicate_return_tag
 # wrong constant name <static-init>
@@ -6045,2562 +6558,1511 @@
 # wrong constant name namespace_for_handler
 # wrong constant name register_handler_namespace
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::AliasHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::AliasHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::AliasHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::AliasHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::AliasHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::AliasHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::AliasHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::AliasHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::AliasHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::AliasHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::AliasHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::AliasHandler::CSEPQ
-#                YARD::Handlers::Ruby::AliasHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::AliasHandler::CSEPQ
-#                YARD::Handlers::Ruby::AliasHandler::CSEP
-#                YARD::Handlers::Ruby::AliasHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::AliasHandler::ISEPQ
 #                YARD::Handlers::Ruby::AliasHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::AliasHandler::ISEPQ
-#                YARD::Handlers::Ruby::AliasHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::AliasHandler::CSEPQ
-#                YARD::Handlers::Ruby::AliasHandler::ISEPQ
-#                YARD::Handlers::Ruby::AliasHandler::ISEP
 #                YARD::Handlers::Ruby::AliasHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::AliasHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::AliasHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::AliasHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::AliasHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::AliasHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::AliasHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::AliasHandler::NSEPQ
-#                YARD::Handlers::Ruby::AliasHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::AliasHandler::CSEPQ
 #                YARD::Handlers::Ruby::AliasHandler::ISEPQ
-#                YARD::Handlers::Ruby::AliasHandler::NSEPQ
-#                YARD::Handlers::Ruby::AliasHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::AliasHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::AliasHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::AttributeHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::AttributeHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::AttributeHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::AttributeHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::AttributeHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::AttributeHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::AttributeHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::AttributeHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::AttributeHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::AttributeHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::AttributeHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::AttributeHandler::CSEPQ
-#                YARD::Handlers::Ruby::AttributeHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::AttributeHandler::CSEPQ
-#                YARD::Handlers::Ruby::AttributeHandler::CSEP
-#                YARD::Handlers::Ruby::AttributeHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::AttributeHandler::ISEPQ
 #                YARD::Handlers::Ruby::AttributeHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::AttributeHandler::ISEPQ
-#                YARD::Handlers::Ruby::AttributeHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::AttributeHandler::CSEPQ
-#                YARD::Handlers::Ruby::AttributeHandler::ISEPQ
-#                YARD::Handlers::Ruby::AttributeHandler::ISEP
 #                YARD::Handlers::Ruby::AttributeHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::AttributeHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::AttributeHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::AttributeHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::AttributeHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::AttributeHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::AttributeHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::AttributeHandler::NSEPQ
-#                YARD::Handlers::Ruby::AttributeHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::AttributeHandler::CSEPQ
 #                YARD::Handlers::Ruby::AttributeHandler::ISEPQ
-#                YARD::Handlers::Ruby::AttributeHandler::NSEPQ
-#                YARD::Handlers::Ruby::AttributeHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::AttributeHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::AttributeHandler::PROXY_MATCH
 # wrong constant name validated_attribute_names
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Base::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Base::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Base::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Base::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Base::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Base::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Base::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Base::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Base::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Base::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Base::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Base::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Base::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Base::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Base::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Base::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Base::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Base::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Base::CSEPQ
-#                YARD::Handlers::Ruby::Base::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Base::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Base::CSEPQ
-#                YARD::Handlers::Ruby::Base::CSEP
-#                YARD::Handlers::Ruby::Base::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Base::ISEPQ
 #                YARD::Handlers::Ruby::Base::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Base::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Base::ISEPQ
-#                YARD::Handlers::Ruby::Base::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Base::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Base::CSEPQ
-#                YARD::Handlers::Ruby::Base::ISEPQ
-#                YARD::Handlers::Ruby::Base::ISEP
 #                YARD::Handlers::Ruby::Base::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Base::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Base::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Base::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Base::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Base::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Base::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Base::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Base::NamespaceMapper
-#                YARD::Handlers::Ruby::Base::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Base::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Base::NSEPQ
-#                YARD::Handlers::Ruby::Base::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Base::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Base::CSEPQ
 #                YARD::Handlers::Ruby::Base::ISEPQ
-#                YARD::Handlers::Ruby::Base::NSEPQ
-#                YARD::Handlers::Ruby::Base::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Base::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Base::PROXY_MATCH
 # wrong constant name parse_block
 # wrong constant name <static-init>
 # wrong constant name handles?
 # wrong constant name meta_type
 # wrong constant name method_call
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::ClassConditionHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::ClassConditionHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::CSEPQ
-#                YARD::Handlers::Ruby::ClassConditionHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::CSEPQ
-#                YARD::Handlers::Ruby::ClassConditionHandler::CSEP
-#                YARD::Handlers::Ruby::ClassConditionHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::ISEPQ
 #                YARD::Handlers::Ruby::ClassConditionHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::ISEPQ
-#                YARD::Handlers::Ruby::ClassConditionHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::CSEPQ
-#                YARD::Handlers::Ruby::ClassConditionHandler::ISEPQ
-#                YARD::Handlers::Ruby::ClassConditionHandler::ISEP
 #                YARD::Handlers::Ruby::ClassConditionHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::ClassConditionHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::ClassConditionHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::NSEPQ
-#                YARD::Handlers::Ruby::ClassConditionHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::CSEPQ
 #                YARD::Handlers::Ruby::ClassConditionHandler::ISEPQ
-#                YARD::Handlers::Ruby::ClassConditionHandler::NSEPQ
-#                YARD::Handlers::Ruby::ClassConditionHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ClassConditionHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::ClassConditionHandler::PROXY_MATCH
 # wrong constant name parse_condition
 # wrong constant name parse_else_block
 # wrong constant name parse_then_block
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::ClassHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::ClassHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::ClassHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::ClassHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::ClassHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::ClassHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::ClassHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::ClassHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::ClassHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::ClassHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::ClassHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::ClassHandler::CSEPQ
-#                YARD::Handlers::Ruby::ClassHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::ClassHandler::CSEPQ
-#                YARD::Handlers::Ruby::ClassHandler::CSEP
-#                YARD::Handlers::Ruby::ClassHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::ClassHandler::ISEPQ
 #                YARD::Handlers::Ruby::ClassHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::ClassHandler::ISEPQ
-#                YARD::Handlers::Ruby::ClassHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::ClassHandler::CSEPQ
-#                YARD::Handlers::Ruby::ClassHandler::ISEPQ
-#                YARD::Handlers::Ruby::ClassHandler::ISEP
 #                YARD::Handlers::Ruby::ClassHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::ClassHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::ClassHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::ClassHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::ClassHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::ClassHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::ClassHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::ClassHandler::NSEPQ
-#                YARD::Handlers::Ruby::ClassHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::ClassHandler::CSEPQ
 #                YARD::Handlers::Ruby::ClassHandler::ISEPQ
-#                YARD::Handlers::Ruby::ClassHandler::NSEPQ
-#                YARD::Handlers::Ruby::ClassHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ClassHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::ClassHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::ClassVariableHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::ClassVariableHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::CSEPQ
-#                YARD::Handlers::Ruby::ClassVariableHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::CSEPQ
-#                YARD::Handlers::Ruby::ClassVariableHandler::CSEP
-#                YARD::Handlers::Ruby::ClassVariableHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::ISEPQ
 #                YARD::Handlers::Ruby::ClassVariableHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::ISEPQ
-#                YARD::Handlers::Ruby::ClassVariableHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::CSEPQ
-#                YARD::Handlers::Ruby::ClassVariableHandler::ISEPQ
-#                YARD::Handlers::Ruby::ClassVariableHandler::ISEP
 #                YARD::Handlers::Ruby::ClassVariableHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::ClassVariableHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::ClassVariableHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::NSEPQ
-#                YARD::Handlers::Ruby::ClassVariableHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::CSEPQ
 #                YARD::Handlers::Ruby::ClassVariableHandler::ISEPQ
-#                YARD::Handlers::Ruby::ClassVariableHandler::NSEPQ
-#                YARD::Handlers::Ruby::ClassVariableHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ClassVariableHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::ClassVariableHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::CommentHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::CommentHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::CommentHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::CommentHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::CommentHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::CommentHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::CommentHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::CommentHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::CommentHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::CommentHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::CommentHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::CommentHandler::CSEPQ
-#                YARD::Handlers::Ruby::CommentHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::CommentHandler::CSEPQ
-#                YARD::Handlers::Ruby::CommentHandler::CSEP
-#                YARD::Handlers::Ruby::CommentHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::CommentHandler::ISEPQ
 #                YARD::Handlers::Ruby::CommentHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::CommentHandler::ISEPQ
-#                YARD::Handlers::Ruby::CommentHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::CommentHandler::CSEPQ
-#                YARD::Handlers::Ruby::CommentHandler::ISEPQ
-#                YARD::Handlers::Ruby::CommentHandler::ISEP
 #                YARD::Handlers::Ruby::CommentHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::CommentHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::CommentHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::CommentHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::CommentHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::CommentHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::CommentHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::CommentHandler::NSEPQ
-#                YARD::Handlers::Ruby::CommentHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::CommentHandler::CSEPQ
 #                YARD::Handlers::Ruby::CommentHandler::ISEPQ
-#                YARD::Handlers::Ruby::CommentHandler::NSEPQ
-#                YARD::Handlers::Ruby::CommentHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::CommentHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::CommentHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::ConstantHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::ConstantHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::ConstantHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::ConstantHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::ConstantHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::ConstantHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::ConstantHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::ConstantHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::ConstantHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::ConstantHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::ConstantHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::ConstantHandler::CSEPQ
-#                YARD::Handlers::Ruby::ConstantHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::ConstantHandler::CSEPQ
-#                YARD::Handlers::Ruby::ConstantHandler::CSEP
-#                YARD::Handlers::Ruby::ConstantHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::ConstantHandler::ISEPQ
 #                YARD::Handlers::Ruby::ConstantHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::ConstantHandler::ISEPQ
-#                YARD::Handlers::Ruby::ConstantHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::ConstantHandler::CSEPQ
-#                YARD::Handlers::Ruby::ConstantHandler::ISEPQ
-#                YARD::Handlers::Ruby::ConstantHandler::ISEP
 #                YARD::Handlers::Ruby::ConstantHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::ConstantHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::ConstantHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::ConstantHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::ConstantHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::ConstantHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::ConstantHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::ConstantHandler::NSEPQ
-#                YARD::Handlers::Ruby::ConstantHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::ConstantHandler::CSEPQ
 #                YARD::Handlers::Ruby::ConstantHandler::ISEPQ
-#                YARD::Handlers::Ruby::ConstantHandler::NSEPQ
-#                YARD::Handlers::Ruby::ConstantHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ConstantHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::ConstantHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::DSLHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::DSLHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::DSLHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::DSLHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::DSLHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::DSLHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::DSLHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::DSLHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::DSLHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::DSLHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::DSLHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::DSLHandler::CSEPQ
-#                YARD::Handlers::Ruby::DSLHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::DSLHandler::CSEPQ
-#                YARD::Handlers::Ruby::DSLHandler::CSEP
-#                YARD::Handlers::Ruby::DSLHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::DSLHandler::ISEPQ
 #                YARD::Handlers::Ruby::DSLHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::IGNORE_METHODS
-# Did you mean?  YARD::Handlers::Ruby::DSLHandler::IGNORE_METHODS
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::DSLHandler::ISEPQ
-#                YARD::Handlers::Ruby::DSLHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::DSLHandler::CSEPQ
-#                YARD::Handlers::Ruby::DSLHandler::ISEPQ
-#                YARD::Handlers::Ruby::DSLHandler::ISEP
 #                YARD::Handlers::Ruby::DSLHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::DSLHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::DSLHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::DSLHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::DSLHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::DSLHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::DSLHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::DSLHandler::NSEPQ
-#                YARD::Handlers::Ruby::DSLHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::DSLHandler::CSEPQ
 #                YARD::Handlers::Ruby::DSLHandler::ISEPQ
-#                YARD::Handlers::Ruby::DSLHandler::NSEPQ
-#                YARD::Handlers::Ruby::DSLHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::DSLHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::DSLHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::DSLHandlerMethods::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::DSLHandlerMethods::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::CSEP
 # Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::CSEPQ
-#                YARD::Handlers::Ruby::DSLHandlerMethods::CSEP
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::CSEPQ
-#                YARD::Handlers::Ruby::DSLHandlerMethods::CSEP
-#                YARD::Handlers::Ruby::DSLHandlerMethods::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::ISEPQ
 #                YARD::Handlers::Ruby::DSLHandlerMethods::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::ISEP
 # Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::ISEPQ
-#                YARD::Handlers::Ruby::DSLHandlerMethods::ISEP
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::CSEPQ
-#                YARD::Handlers::Ruby::DSLHandlerMethods::ISEPQ
-#                YARD::Handlers::Ruby::DSLHandlerMethods::ISEP
 #                YARD::Handlers::Ruby::DSLHandlerMethods::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::DSLHandlerMethods::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::NamespaceMapper
-#                YARD::Handlers::Ruby::DSLHandlerMethods::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::NSEP
 # Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::NSEPQ
-#                YARD::Handlers::Ruby::DSLHandlerMethods::NSEP
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::CSEPQ
 #                YARD::Handlers::Ruby::DSLHandlerMethods::ISEPQ
-#                YARD::Handlers::Ruby::DSLHandlerMethods::NSEPQ
-#                YARD::Handlers::Ruby::DSLHandlerMethods::NSEP
 # uninitialized constant YARD::Handlers::Ruby::DSLHandlerMethods::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::DSLHandlerMethods::PROXY_MATCH
 # wrong constant name handle_comments
 # wrong constant name register_docstring
 # wrong constant name <static-init>
 # wrong constant name process_decorator
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::ExceptionHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::ExceptionHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::CSEPQ
-#                YARD::Handlers::Ruby::ExceptionHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::CSEPQ
-#                YARD::Handlers::Ruby::ExceptionHandler::CSEP
-#                YARD::Handlers::Ruby::ExceptionHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::ISEPQ
 #                YARD::Handlers::Ruby::ExceptionHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::ISEPQ
-#                YARD::Handlers::Ruby::ExceptionHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::CSEPQ
-#                YARD::Handlers::Ruby::ExceptionHandler::ISEPQ
-#                YARD::Handlers::Ruby::ExceptionHandler::ISEP
 #                YARD::Handlers::Ruby::ExceptionHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::ExceptionHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::ExceptionHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::NSEPQ
-#                YARD::Handlers::Ruby::ExceptionHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::CSEPQ
 #                YARD::Handlers::Ruby::ExceptionHandler::ISEPQ
-#                YARD::Handlers::Ruby::ExceptionHandler::NSEPQ
-#                YARD::Handlers::Ruby::ExceptionHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ExceptionHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::ExceptionHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::ExtendHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::ExtendHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::ExtendHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::ExtendHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::ExtendHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::ExtendHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::ExtendHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::ExtendHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::ExtendHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::ExtendHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::ExtendHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::ExtendHandler::CSEPQ
-#                YARD::Handlers::Ruby::ExtendHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::ExtendHandler::CSEPQ
-#                YARD::Handlers::Ruby::ExtendHandler::CSEP
-#                YARD::Handlers::Ruby::ExtendHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::ExtendHandler::ISEPQ
 #                YARD::Handlers::Ruby::ExtendHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::ExtendHandler::ISEPQ
-#                YARD::Handlers::Ruby::ExtendHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::ExtendHandler::CSEPQ
-#                YARD::Handlers::Ruby::ExtendHandler::ISEPQ
-#                YARD::Handlers::Ruby::ExtendHandler::ISEP
 #                YARD::Handlers::Ruby::ExtendHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::ExtendHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::ExtendHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::ExtendHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::ExtendHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::ExtendHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::ExtendHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::ExtendHandler::NSEPQ
-#                YARD::Handlers::Ruby::ExtendHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::ExtendHandler::CSEPQ
 #                YARD::Handlers::Ruby::ExtendHandler::ISEPQ
-#                YARD::Handlers::Ruby::ExtendHandler::NSEPQ
-#                YARD::Handlers::Ruby::ExtendHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ExtendHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::ExtendHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::AliasHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::AliasHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::AliasHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::AliasHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AliasHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AliasHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::AttributeHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::AttributeHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::AttributeHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::AttributeHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::AttributeHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::AttributeHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::Base::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::Base::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::Base::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::Base::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::Base::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::Base::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::Base::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::Base::CSEP
-#                YARD::Handlers::Ruby::Legacy::Base::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::Base::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::Base::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::Base::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::Base::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::Base::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::Base::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::Base::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::Base::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::Base::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::Base::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::Base::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::Base::ISEP
 #                YARD::Handlers::Ruby::Legacy::Base::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::Base::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::Base::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::Base::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::Base::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::Base::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::Base::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::Base::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::Base::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::Base::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::Base::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::Base::TokenDefinitions
 # wrong constant name parse_block
 # wrong constant name <static-init>
 # wrong constant name handles?
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassConditionHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassConditionHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassConditionHandler::TokenDefinitions
 # wrong constant name parse_condition
 # wrong constant name parse_else_block
 # wrong constant name parse_then_block
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::ClassHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::ClassHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::ClassHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ClassVariableHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ClassVariableHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ClassVariableHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::CommentHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::CommentHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::CommentHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::CommentHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::CommentHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::CommentHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::ConstantHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::ConstantHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::ConstantHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ConstantHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ConstantHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ConstantHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::DSLHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::IGNORE_METHODS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::IGNORE_METHODS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::DSLHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::DSLHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::DSLHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::DSLHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::DSLHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::ExceptionHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::ExceptionHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::ExceptionHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ExceptionHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExceptionHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExceptionHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::ExtendHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::ExtendHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::ExtendHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ExtendHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ExtendHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ExtendHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::MethodHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::MethodHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::MethodHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::MethodHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MethodHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MethodHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::MixinHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::MixinHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::MixinHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::MixinHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::MixinHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::MixinHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleFunctionHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::ModuleHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::ModuleHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::ModuleHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::ModuleHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::ModuleHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::ModuleHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateClassMethodHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::PrivateConstantHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::VisibilityHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::VisibilityHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::VisibilityHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::VisibilityHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::VisibilityHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::VisibilityHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::CSEP
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::ISEPQ
 #                YARD::Handlers::Ruby::Legacy::YieldHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_ARG
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_BEG
+# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_BEG
 # Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_ARG
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_BEG
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_CLASS
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_CLASS
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_DOT
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_DOT
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_END
 # Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_FNAME
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_FNAME
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_MID
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_MID
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_END
+# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::EXPR_END
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::CSEPQ
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::ISEP
 #                YARD::Handlers::Ruby::Legacy::YieldHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::NEWLINE_TOKEN
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::NEWLINE_TOKEN
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::CSEPQ
 #                YARD::Handlers::Ruby::Legacy::YieldHandler::ISEPQ
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::NSEPQ
-#                YARD::Handlers::Ruby::Legacy::YieldHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::PROXY_MATCH
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::TkReading2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::TkReading2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::TkSymbol2Token
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::TkSymbol2Token
 # uninitialized constant YARD::Handlers::Ruby::Legacy::YieldHandler::TokenDefinitions
-# Did you mean?  YARD::Handlers::Ruby::Legacy::YieldHandler::TokenDefinitions
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::MethodConditionHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::MethodConditionHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::CSEPQ
-#                YARD::Handlers::Ruby::MethodConditionHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::CSEPQ
-#                YARD::Handlers::Ruby::MethodConditionHandler::CSEP
-#                YARD::Handlers::Ruby::MethodConditionHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::ISEPQ
 #                YARD::Handlers::Ruby::MethodConditionHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::ISEPQ
-#                YARD::Handlers::Ruby::MethodConditionHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::CSEPQ
-#                YARD::Handlers::Ruby::MethodConditionHandler::ISEPQ
-#                YARD::Handlers::Ruby::MethodConditionHandler::ISEP
 #                YARD::Handlers::Ruby::MethodConditionHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::MethodConditionHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::MethodConditionHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::NSEPQ
-#                YARD::Handlers::Ruby::MethodConditionHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::CSEPQ
 #                YARD::Handlers::Ruby::MethodConditionHandler::ISEPQ
-#                YARD::Handlers::Ruby::MethodConditionHandler::NSEPQ
-#                YARD::Handlers::Ruby::MethodConditionHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::MethodConditionHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::MethodConditionHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::MethodHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::MethodHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::MethodHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::MethodHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::MethodHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::MethodHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::MethodHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::MethodHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::MethodHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::MethodHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::MethodHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::MethodHandler::CSEPQ
-#                YARD::Handlers::Ruby::MethodHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::MethodHandler::CSEPQ
-#                YARD::Handlers::Ruby::MethodHandler::CSEP
-#                YARD::Handlers::Ruby::MethodHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::MethodHandler::ISEPQ
 #                YARD::Handlers::Ruby::MethodHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::MethodHandler::ISEPQ
-#                YARD::Handlers::Ruby::MethodHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::MethodHandler::CSEPQ
-#                YARD::Handlers::Ruby::MethodHandler::ISEPQ
-#                YARD::Handlers::Ruby::MethodHandler::ISEP
 #                YARD::Handlers::Ruby::MethodHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::MethodHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::MethodHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::MethodHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::MethodHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::MethodHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::MethodHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::MethodHandler::NSEPQ
-#                YARD::Handlers::Ruby::MethodHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::MethodHandler::CSEPQ
 #                YARD::Handlers::Ruby::MethodHandler::ISEPQ
-#                YARD::Handlers::Ruby::MethodHandler::NSEPQ
-#                YARD::Handlers::Ruby::MethodHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::MethodHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::MethodHandler::PROXY_MATCH
 # wrong constant name format_args
 # wrong constant name method_signature
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::MixinHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::MixinHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::MixinHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::MixinHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::MixinHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::MixinHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::MixinHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::MixinHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::MixinHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::MixinHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::MixinHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::MixinHandler::CSEPQ
-#                YARD::Handlers::Ruby::MixinHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::MixinHandler::CSEPQ
-#                YARD::Handlers::Ruby::MixinHandler::CSEP
-#                YARD::Handlers::Ruby::MixinHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::MixinHandler::ISEPQ
 #                YARD::Handlers::Ruby::MixinHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::MixinHandler::ISEPQ
-#                YARD::Handlers::Ruby::MixinHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::MixinHandler::CSEPQ
-#                YARD::Handlers::Ruby::MixinHandler::ISEPQ
-#                YARD::Handlers::Ruby::MixinHandler::ISEP
 #                YARD::Handlers::Ruby::MixinHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::MixinHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::MixinHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::MixinHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::MixinHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::MixinHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::MixinHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::MixinHandler::NSEPQ
-#                YARD::Handlers::Ruby::MixinHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::MixinHandler::CSEPQ
 #                YARD::Handlers::Ruby::MixinHandler::ISEPQ
-#                YARD::Handlers::Ruby::MixinHandler::NSEPQ
-#                YARD::Handlers::Ruby::MixinHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::MixinHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::MixinHandler::PROXY_MATCH
 # wrong constant name process_mixin
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::ModuleFunctionHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::ModuleFunctionHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::CSEPQ
-#                YARD::Handlers::Ruby::ModuleFunctionHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::CSEPQ
-#                YARD::Handlers::Ruby::ModuleFunctionHandler::CSEP
-#                YARD::Handlers::Ruby::ModuleFunctionHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::ISEPQ
 #                YARD::Handlers::Ruby::ModuleFunctionHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::ISEPQ
-#                YARD::Handlers::Ruby::ModuleFunctionHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::CSEPQ
-#                YARD::Handlers::Ruby::ModuleFunctionHandler::ISEPQ
-#                YARD::Handlers::Ruby::ModuleFunctionHandler::ISEP
 #                YARD::Handlers::Ruby::ModuleFunctionHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::ModuleFunctionHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::ModuleFunctionHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::NSEPQ
-#                YARD::Handlers::Ruby::ModuleFunctionHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::CSEPQ
 #                YARD::Handlers::Ruby::ModuleFunctionHandler::ISEPQ
-#                YARD::Handlers::Ruby::ModuleFunctionHandler::NSEPQ
-#                YARD::Handlers::Ruby::ModuleFunctionHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ModuleFunctionHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::ModuleFunctionHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::ModuleHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::ModuleHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::ModuleHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::ModuleHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::ModuleHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::ModuleHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::ModuleHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::ModuleHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::ModuleHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::ModuleHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::ModuleHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::ModuleHandler::CSEPQ
-#                YARD::Handlers::Ruby::ModuleHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::ModuleHandler::CSEPQ
-#                YARD::Handlers::Ruby::ModuleHandler::CSEP
-#                YARD::Handlers::Ruby::ModuleHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::ModuleHandler::ISEPQ
 #                YARD::Handlers::Ruby::ModuleHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::ModuleHandler::ISEPQ
-#                YARD::Handlers::Ruby::ModuleHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::ModuleHandler::CSEPQ
-#                YARD::Handlers::Ruby::ModuleHandler::ISEPQ
-#                YARD::Handlers::Ruby::ModuleHandler::ISEP
 #                YARD::Handlers::Ruby::ModuleHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::ModuleHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::ModuleHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::ModuleHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::ModuleHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::ModuleHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::ModuleHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::ModuleHandler::NSEPQ
-#                YARD::Handlers::Ruby::ModuleHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::ModuleHandler::CSEPQ
 #                YARD::Handlers::Ruby::ModuleHandler::ISEPQ
-#                YARD::Handlers::Ruby::ModuleHandler::NSEPQ
-#                YARD::Handlers::Ruby::ModuleHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::ModuleHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::ModuleHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::PrivateClassMethodHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::PrivateClassMethodHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::CSEPQ
-#                YARD::Handlers::Ruby::PrivateClassMethodHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::CSEPQ
-#                YARD::Handlers::Ruby::PrivateClassMethodHandler::CSEP
-#                YARD::Handlers::Ruby::PrivateClassMethodHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::ISEPQ
 #                YARD::Handlers::Ruby::PrivateClassMethodHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::ISEPQ
-#                YARD::Handlers::Ruby::PrivateClassMethodHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::CSEPQ
-#                YARD::Handlers::Ruby::PrivateClassMethodHandler::ISEPQ
-#                YARD::Handlers::Ruby::PrivateClassMethodHandler::ISEP
 #                YARD::Handlers::Ruby::PrivateClassMethodHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::PrivateClassMethodHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::PrivateClassMethodHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::NSEPQ
-#                YARD::Handlers::Ruby::PrivateClassMethodHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::CSEPQ
 #                YARD::Handlers::Ruby::PrivateClassMethodHandler::ISEPQ
-#                YARD::Handlers::Ruby::PrivateClassMethodHandler::NSEPQ
-#                YARD::Handlers::Ruby::PrivateClassMethodHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::PrivateClassMethodHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::PrivateClassMethodHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::PrivateConstantHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::PrivateConstantHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::CSEPQ
-#                YARD::Handlers::Ruby::PrivateConstantHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::CSEPQ
-#                YARD::Handlers::Ruby::PrivateConstantHandler::CSEP
-#                YARD::Handlers::Ruby::PrivateConstantHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::ISEPQ
 #                YARD::Handlers::Ruby::PrivateConstantHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::ISEPQ
-#                YARD::Handlers::Ruby::PrivateConstantHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::CSEPQ
-#                YARD::Handlers::Ruby::PrivateConstantHandler::ISEPQ
-#                YARD::Handlers::Ruby::PrivateConstantHandler::ISEP
 #                YARD::Handlers::Ruby::PrivateConstantHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::PrivateConstantHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::PrivateConstantHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::NSEPQ
-#                YARD::Handlers::Ruby::PrivateConstantHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::CSEPQ
 #                YARD::Handlers::Ruby::PrivateConstantHandler::ISEPQ
-#                YARD::Handlers::Ruby::PrivateConstantHandler::NSEPQ
-#                YARD::Handlers::Ruby::PrivateConstantHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::PrivateConstantHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::PrivateConstantHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::PublicClassMethodHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::PublicClassMethodHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::CSEPQ
-#                YARD::Handlers::Ruby::PublicClassMethodHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::CSEPQ
-#                YARD::Handlers::Ruby::PublicClassMethodHandler::CSEP
-#                YARD::Handlers::Ruby::PublicClassMethodHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::ISEPQ
 #                YARD::Handlers::Ruby::PublicClassMethodHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::ISEPQ
-#                YARD::Handlers::Ruby::PublicClassMethodHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::CSEPQ
-#                YARD::Handlers::Ruby::PublicClassMethodHandler::ISEPQ
-#                YARD::Handlers::Ruby::PublicClassMethodHandler::ISEP
 #                YARD::Handlers::Ruby::PublicClassMethodHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::PublicClassMethodHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::PublicClassMethodHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::NSEPQ
-#                YARD::Handlers::Ruby::PublicClassMethodHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::CSEPQ
 #                YARD::Handlers::Ruby::PublicClassMethodHandler::ISEPQ
-#                YARD::Handlers::Ruby::PublicClassMethodHandler::NSEPQ
-#                YARD::Handlers::Ruby::PublicClassMethodHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::PublicClassMethodHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::PublicClassMethodHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::StructHandlerMethods::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::StructHandlerMethods::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::CSEP
 # Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::CSEPQ
-#                YARD::Handlers::Ruby::StructHandlerMethods::CSEP
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::CSEPQ
-#                YARD::Handlers::Ruby::StructHandlerMethods::CSEP
-#                YARD::Handlers::Ruby::StructHandlerMethods::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::ISEPQ
 #                YARD::Handlers::Ruby::StructHandlerMethods::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::ISEP
 # Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::ISEPQ
-#                YARD::Handlers::Ruby::StructHandlerMethods::ISEP
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::CSEPQ
-#                YARD::Handlers::Ruby::StructHandlerMethods::ISEPQ
-#                YARD::Handlers::Ruby::StructHandlerMethods::ISEP
 #                YARD::Handlers::Ruby::StructHandlerMethods::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::StructHandlerMethods::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::NamespaceMapper
-#                YARD::Handlers::Ruby::StructHandlerMethods::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::NSEP
 # Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::NSEPQ
-#                YARD::Handlers::Ruby::StructHandlerMethods::NSEP
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::CSEPQ
 #                YARD::Handlers::Ruby::StructHandlerMethods::ISEPQ
-#                YARD::Handlers::Ruby::StructHandlerMethods::NSEPQ
-#                YARD::Handlers::Ruby::StructHandlerMethods::NSEP
 # uninitialized constant YARD::Handlers::Ruby::StructHandlerMethods::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::StructHandlerMethods::PROXY_MATCH
 # wrong constant name add_reader_tags
 # wrong constant name add_writer_tags
 # wrong constant name create_attributes
@@ -8613,106 +8075,64 @@
 # wrong constant name return_type_from_tag
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::VisibilityHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::VisibilityHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::CSEPQ
-#                YARD::Handlers::Ruby::VisibilityHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::CSEPQ
-#                YARD::Handlers::Ruby::VisibilityHandler::CSEP
-#                YARD::Handlers::Ruby::VisibilityHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::ISEPQ
 #                YARD::Handlers::Ruby::VisibilityHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::ISEPQ
-#                YARD::Handlers::Ruby::VisibilityHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::CSEPQ
-#                YARD::Handlers::Ruby::VisibilityHandler::ISEPQ
-#                YARD::Handlers::Ruby::VisibilityHandler::ISEP
 #                YARD::Handlers::Ruby::VisibilityHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::VisibilityHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::VisibilityHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::NSEPQ
-#                YARD::Handlers::Ruby::VisibilityHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::CSEPQ
 #                YARD::Handlers::Ruby::VisibilityHandler::ISEPQ
-#                YARD::Handlers::Ruby::VisibilityHandler::NSEPQ
-#                YARD::Handlers::Ruby::VisibilityHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::VisibilityHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::VisibilityHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::BUILTIN_ALL
-# Did you mean?  YARD::Handlers::Ruby::YieldHandler::BUILTIN_ALL
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::BUILTIN_CLASSES
-# Did you mean?  YARD::Handlers::Ruby::YieldHandler::BUILTIN_CLASSES
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Handlers::Ruby::YieldHandler::BUILTIN_EXCEPTIONS
-#                YARD::Handlers::Ruby::YieldHandler::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Handlers::Ruby::YieldHandler::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Handlers::Ruby::YieldHandler::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Handlers::Ruby::YieldHandler::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Handlers::Ruby::YieldHandler::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::BUILTIN_MODULES
-# Did you mean?  YARD::Handlers::Ruby::YieldHandler::BUILTIN_MODULES
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::CONSTANTMATCH
-# Did you mean?  YARD::Handlers::Ruby::YieldHandler::CONSTANTMATCH
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::CONSTANTSTART
-# Did you mean?  YARD::Handlers::Ruby::YieldHandler::CONSTANTSTART
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::CSEP
 # Did you mean?  YARD::Handlers::Ruby::YieldHandler::CSEPQ
-#                YARD::Handlers::Ruby::YieldHandler::CSEP
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::CSEPQ
-# Did you mean?  YARD::Handlers::Ruby::YieldHandler::CSEPQ
-#                YARD::Handlers::Ruby::YieldHandler::CSEP
-#                YARD::Handlers::Ruby::YieldHandler::ISEPQ
+# Did you mean?  YARD::Handlers::Ruby::YieldHandler::ISEPQ
 #                YARD::Handlers::Ruby::YieldHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::ISEP
 # Did you mean?  YARD::Handlers::Ruby::YieldHandler::ISEPQ
-#                YARD::Handlers::Ruby::YieldHandler::ISEP
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::ISEPQ
 # Did you mean?  YARD::Handlers::Ruby::YieldHandler::CSEPQ
-#                YARD::Handlers::Ruby::YieldHandler::ISEPQ
-#                YARD::Handlers::Ruby::YieldHandler::ISEP
 #                YARD::Handlers::Ruby::YieldHandler::NSEPQ
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::METHODMATCH
-# Did you mean?  YARD::Handlers::Ruby::YieldHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::METHODNAMEMATCH
-# Did you mean?  YARD::Handlers::Ruby::YieldHandler::METHODNAMEMATCH
-#                YARD::Handlers::Ruby::YieldHandler::METHODMATCH
+# Did you mean?  YARD::Handlers::Ruby::YieldHandler::METHODMATCH
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::NAMESPACEMATCH
 # Did you mean?  YARD::Handlers::Ruby::YieldHandler::NamespaceMapper
-#                YARD::Handlers::Ruby::YieldHandler::NAMESPACEMATCH
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::NSEP
 # Did you mean?  YARD::Handlers::Ruby::YieldHandler::NSEPQ
-#                YARD::Handlers::Ruby::YieldHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::NSEPQ
 # Did you mean?  YARD::Handlers::Ruby::YieldHandler::CSEPQ
 #                YARD::Handlers::Ruby::YieldHandler::ISEPQ
-#                YARD::Handlers::Ruby::YieldHandler::NSEPQ
-#                YARD::Handlers::Ruby::YieldHandler::NSEP
 # uninitialized constant YARD::Handlers::Ruby::YieldHandler::PROXY_MATCH
-# Did you mean?  YARD::Handlers::Ruby::YieldHandler::PROXY_MATCH
 # wrong constant name <static-init>
 # wrong constant name initialize
 # wrong constant name load
@@ -8748,27 +8168,18 @@
 # wrong constant name <static-init>
 # wrong constant name <<
 # uninitialized constant YARD::Logger::DEBUG
-# Did you mean?  YARD::Logger::DEBUG
 # uninitialized constant YARD::Logger::ERROR
 # Did you mean?  YARD::Logger::Error
 #                IOError
 #                Errno
-#                YARD::Logger::ERROR
 # uninitialized constant YARD::Logger::FATAL
-# Did you mean?  YARD::Logger::FATAL
 # uninitialized constant YARD::Logger::INFO
-# Did you mean?  YARD::Logger::INFO
 # uninitialized constant YARD::Logger::ProgName
-# Did you mean?  YARD::Logger::ProgName
 # uninitialized constant YARD::Logger::SEV_LABEL
-# Did you mean?  YARD::Logger::SEV_LABEL
 # uninitialized constant YARD::Logger::UNKNOWN
-# Did you mean?  YARD::Logger::UNKNOWN
 # uninitialized constant YARD::Logger::VERSION
-# Did you mean?  YARD::Logger::VERSION
-#                YARD::VERSION
+# Did you mean?  YARD::VERSION
 # uninitialized constant YARD::Logger::WARN
-# Did you mean?  YARD::Logger::WARN
 # wrong constant name backtrace
 # wrong constant name capture
 # wrong constant name clear_progress
@@ -8837,22 +8248,15 @@
 # wrong constant name validated_parser_type
 # wrong constant name <static-init>
 # uninitialized constant YARD::Rake::YardocTask::DEFAULT
-# Did you mean?  YARD::Rake::YardocTask::DEFAULT
 # uninitialized constant YARD::Rake::YardocTask::LN_SUPPORTED
-# Did you mean?  YARD::Rake::YardocTask::LN_SUPPORTED
 # uninitialized constant YARD::Rake::YardocTask::LOW_METHODS
 # Did you mean?  YARD::Rake::YardocTask::LowMethods
-#                YARD::Rake::YardocTask::LOW_METHODS
 # uninitialized constant YARD::Rake::YardocTask::METHODS
 # Did you mean?  Method
-#                YARD::Rake::YardocTask::METHODS
 # uninitialized constant YARD::Rake::YardocTask::OPT_TABLE
-# Did you mean?  YARD::Rake::YardocTask::OPT_TABLE
 # uninitialized constant YARD::Rake::YardocTask::RUBY
-# Did you mean?  YARD::Rake::YardocTask::RUBY
 # uninitialized constant YARD::Rake::YardocTask::VERSION
-# Did you mean?  YARD::Rake::YardocTask::VERSION
-#                YARD::VERSION
+# Did you mean?  YARD::VERSION
 # wrong constant name after
 # wrong constant name after=
 # wrong constant name before
@@ -9005,16 +8409,13 @@
 # wrong constant name status=
 # wrong constant name <static-init>
 # uninitialized constant YARD::Server::Commands::DisplayFileCommand::CAN_FORK
-# Did you mean?  YARD::Server::Commands::DisplayFileCommand::CAN_FORK
 # wrong constant name index
 # wrong constant name index=
 # wrong constant name <static-init>
 # uninitialized constant YARD::Server::Commands::DisplayObjectCommand::CAN_FORK
-# Did you mean?  YARD::Server::Commands::DisplayObjectCommand::CAN_FORK
 # wrong constant name index
 # wrong constant name <static-init>
 # uninitialized constant YARD::Server::Commands::FramesCommand::CAN_FORK
-# Did you mean?  YARD::Server::Commands::FramesCommand::CAN_FORK
 # wrong constant name <static-init>
 # wrong constant name incremental
 # wrong constant name incremental=
@@ -9033,25 +8434,17 @@
 # wrong constant name options=
 # wrong constant name <static-init>
 # uninitialized constant YARD::Server::Commands::ListCommand::CAN_FORK
-# Did you mean?  YARD::Server::Commands::ListCommand::CAN_FORK
 # wrong constant name <static-init>
 # uninitialized constant YARD::Server::Commands::RootRequestCommand::DefaultMimeTypes
-# Did you mean?  YARD::Server::Commands::RootRequestCommand::DefaultMimeTypes
 # uninitialized constant YARD::Server::Commands::RootRequestCommand::ESCAPED
 # Did you mean?  YARD::Server::Commands::RootRequestCommand::UNESCAPED
-#                YARD::Server::Commands::RootRequestCommand::ESCAPED
 # uninitialized constant YARD::Server::Commands::RootRequestCommand::NONASCII
-# Did you mean?  YARD::Server::Commands::RootRequestCommand::NONASCII
 # uninitialized constant YARD::Server::Commands::RootRequestCommand::UNESCAPED
-# Did you mean?  YARD::Server::Commands::RootRequestCommand::UNESCAPED
-#                YARD::Server::Commands::RootRequestCommand::ESCAPED
+# Did you mean?  YARD::Server::Commands::RootRequestCommand::ESCAPED
 # uninitialized constant YARD::Server::Commands::RootRequestCommand::UNESCAPED_FORM
-# Did you mean?  YARD::Server::Commands::RootRequestCommand::UNESCAPED_FORM
 # uninitialized constant YARD::Server::Commands::RootRequestCommand::UNESCAPED_PCHAR
-# Did you mean?  YARD::Server::Commands::RootRequestCommand::UNESCAPED_PCHAR
 # wrong constant name <static-init>
 # uninitialized constant YARD::Server::Commands::SearchCommand::CAN_FORK
-# Did you mean?  YARD::Server::Commands::SearchCommand::CAN_FORK
 # wrong constant name query
 # wrong constant name query=
 # wrong constant name results
@@ -9059,36 +8452,23 @@
 # wrong constant name visible_results
 # wrong constant name <static-init>
 # uninitialized constant YARD::Server::Commands::StaticFileCommand::CAN_FORK
-# Did you mean?  YARD::Server::Commands::StaticFileCommand::CAN_FORK
 # uninitialized constant YARD::Server::Commands::StaticFileCommand::DefaultMimeTypes
-# Did you mean?  YARD::Server::Commands::StaticFileCommand::DefaultMimeTypes
 # uninitialized constant YARD::Server::Commands::StaticFileCommand::ESCAPED
 # Did you mean?  YARD::Server::Commands::StaticFileCommand::UNESCAPED
-#                YARD::Server::Commands::StaticFileCommand::ESCAPED
 # uninitialized constant YARD::Server::Commands::StaticFileCommand::NONASCII
-# Did you mean?  YARD::Server::Commands::StaticFileCommand::NONASCII
 # uninitialized constant YARD::Server::Commands::StaticFileCommand::UNESCAPED
-# Did you mean?  YARD::Server::Commands::StaticFileCommand::UNESCAPED
-#                YARD::Server::Commands::StaticFileCommand::ESCAPED
+# Did you mean?  YARD::Server::Commands::StaticFileCommand::ESCAPED
 # uninitialized constant YARD::Server::Commands::StaticFileCommand::UNESCAPED_FORM
-# Did you mean?  YARD::Server::Commands::StaticFileCommand::UNESCAPED_FORM
 # uninitialized constant YARD::Server::Commands::StaticFileCommand::UNESCAPED_PCHAR
-# Did you mean?  YARD::Server::Commands::StaticFileCommand::UNESCAPED_PCHAR
 # wrong constant name <static-init>
 # uninitialized constant YARD::Server::Commands::StaticFileHelpers::DefaultMimeTypes
-# Did you mean?  YARD::Server::Commands::StaticFileHelpers::DefaultMimeTypes
 # uninitialized constant YARD::Server::Commands::StaticFileHelpers::ESCAPED
 # Did you mean?  YARD::Server::Commands::StaticFileHelpers::UNESCAPED
-#                YARD::Server::Commands::StaticFileHelpers::ESCAPED
 # uninitialized constant YARD::Server::Commands::StaticFileHelpers::NONASCII
-# Did you mean?  YARD::Server::Commands::StaticFileHelpers::NONASCII
 # uninitialized constant YARD::Server::Commands::StaticFileHelpers::UNESCAPED
-# Did you mean?  YARD::Server::Commands::StaticFileHelpers::UNESCAPED
-#                YARD::Server::Commands::StaticFileHelpers::ESCAPED
+# Did you mean?  YARD::Server::Commands::StaticFileHelpers::ESCAPED
 # uninitialized constant YARD::Server::Commands::StaticFileHelpers::UNESCAPED_FORM
-# Did you mean?  YARD::Server::Commands::StaticFileHelpers::UNESCAPED_FORM
 # uninitialized constant YARD::Server::Commands::StaticFileHelpers::UNESCAPED_PCHAR
-# Did you mean?  YARD::Server::Commands::StaticFileHelpers::UNESCAPED_PCHAR
 # wrong constant name favicon?
 # wrong constant name static_template_file?
 # wrong constant name <static-init>
@@ -9166,7 +8546,6 @@
 # wrong constant name <static-init>
 # wrong constant name _load
 # uninitialized constant YARD::Tags::AttributeDirective::SCOPE_MATCH
-# Did you mean?  YARD::Tags::AttributeDirective::SCOPE_MATCH
 # wrong constant name <static-init>
 # wrong constant name parse_tag
 # wrong constant name parse_tag_with_name
@@ -9319,55 +8698,34 @@
 # wrong constant name value_types=
 # wrong constant name <static-init>
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::BUILTIN_ALL
-# Did you mean?  YARD::Tags::TypesExplainer::Parser::BUILTIN_ALL
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::BUILTIN_CLASSES
-# Did you mean?  YARD::Tags::TypesExplainer::Parser::BUILTIN_CLASSES
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::BUILTIN_EXCEPTIONS
-# Did you mean?  YARD::Tags::TypesExplainer::Parser::BUILTIN_EXCEPTIONS
-#                YARD::Tags::TypesExplainer::Parser::BUILTIN_EXCEPTIONS_HASH
-# uninitialized constant YARD::Tags::TypesExplainer::Parser::BUILTIN_EXCEPTIONS_HASH
 # Did you mean?  YARD::Tags::TypesExplainer::Parser::BUILTIN_EXCEPTIONS_HASH
-#                YARD::Tags::TypesExplainer::Parser::BUILTIN_EXCEPTIONS
+# uninitialized constant YARD::Tags::TypesExplainer::Parser::BUILTIN_EXCEPTIONS_HASH
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::BUILTIN_MODULES
-# Did you mean?  YARD::Tags::TypesExplainer::Parser::BUILTIN_MODULES
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::CONSTANTMATCH
-# Did you mean?  YARD::Tags::TypesExplainer::Parser::CONSTANTMATCH
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::CONSTANTSTART
-# Did you mean?  YARD::Tags::TypesExplainer::Parser::CONSTANTSTART
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::CSEP
 # Did you mean?  YARD::Tags::TypesExplainer::Parser::CSEPQ
-#                YARD::Tags::TypesExplainer::Parser::CSEP
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::CSEPQ
-# Did you mean?  YARD::Tags::TypesExplainer::Parser::CSEPQ
-#                YARD::Tags::TypesExplainer::Parser::CSEP
-#                YARD::Tags::TypesExplainer::Parser::ISEPQ
+# Did you mean?  YARD::Tags::TypesExplainer::Parser::ISEPQ
 #                YARD::Tags::TypesExplainer::Parser::NSEPQ
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::ISEP
 # Did you mean?  YARD::Tags::TypesExplainer::Parser::ISEPQ
-#                YARD::Tags::TypesExplainer::Parser::ISEP
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::ISEPQ
 # Did you mean?  YARD::Tags::TypesExplainer::Parser::CSEPQ
-#                YARD::Tags::TypesExplainer::Parser::ISEPQ
-#                YARD::Tags::TypesExplainer::Parser::ISEP
 #                YARD::Tags::TypesExplainer::Parser::NSEPQ
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::METHODMATCH
-# Did you mean?  YARD::Tags::TypesExplainer::Parser::METHODMATCH
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::METHODNAMEMATCH
-# Did you mean?  YARD::Tags::TypesExplainer::Parser::METHODNAMEMATCH
-#                YARD::Tags::TypesExplainer::Parser::METHODMATCH
+# Did you mean?  YARD::Tags::TypesExplainer::Parser::METHODMATCH
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::NAMESPACEMATCH
 # Did you mean?  YARD::Tags::TypesExplainer::Parser::NamespaceMapper
-#                YARD::Tags::TypesExplainer::Parser::NAMESPACEMATCH
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::NSEP
 # Did you mean?  YARD::Tags::TypesExplainer::Parser::NSEPQ
-#                YARD::Tags::TypesExplainer::Parser::NSEP
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::NSEPQ
 # Did you mean?  YARD::Tags::TypesExplainer::Parser::CSEPQ
 #                YARD::Tags::TypesExplainer::Parser::ISEPQ
-#                YARD::Tags::TypesExplainer::Parser::NSEPQ
-#                YARD::Tags::TypesExplainer::Parser::NSEP
 # uninitialized constant YARD::Tags::TypesExplainer::Parser::PROXY_MATCH
-# Did you mean?  YARD::Tags::TypesExplainer::Parser::PROXY_MATCH
 # wrong constant name initialize
 # wrong constant name parse
 # wrong constant name <static-init>
@@ -9418,11 +8776,8 @@
 # wrong constant name is_namespace?
 # wrong constant name <static-init>
 # uninitialized constant YARD::Templates::Helpers::HtmlHelper::MARKUP_EXTENSIONS
-# Did you mean?  YARD::Templates::Helpers::HtmlHelper::MARKUP_EXTENSIONS
 # uninitialized constant YARD::Templates::Helpers::HtmlHelper::MARKUP_FILE_SHEBANG
-# Did you mean?  YARD::Templates::Helpers::HtmlHelper::MARKUP_FILE_SHEBANG
 # uninitialized constant YARD::Templates::Helpers::HtmlHelper::MARKUP_PROVIDERS
-# Did you mean?  YARD::Templates::Helpers::HtmlHelper::MARKUP_PROVIDERS
 # wrong constant name anchor_for
 # wrong constant name charset
 # wrong constant name format_object_name_list
@@ -9479,7 +8834,6 @@
 # wrong constant name <Class:BlockQuote>
 # wrong constant name <Class:Document>
 # wrong constant name <Class:Formatter>
-# wrong constant name <Class:FormatterTestCase>
 # wrong constant name <Class:HardBreak>
 # wrong constant name <Class:Heading>
 # wrong constant name <Class:Include>
@@ -9490,9 +8844,8 @@
 # wrong constant name <Class:Parser>
 # wrong constant name <Class:PreProcess>
 # wrong constant name <Class:Raw>
+# wrong constant name <Class:RegexpHandling>
 # wrong constant name <Class:Rule>
-# wrong constant name <Class:Special>
-# wrong constant name <Class:TextFormatterTestCase>
 # wrong constant name <Class:ToAnsi>
 # wrong constant name <Class:ToBs>
 # wrong constant name <Class:ToHtml>
@@ -9507,7 +8860,7 @@
 # wrong constant name <Class:ToTtOnly>
 # wrong constant name <Class:Verbatim>
 # wrong constant name add_html
-# wrong constant name add_special
+# wrong constant name add_regexp_handling
 # wrong constant name add_word_pair
 # wrong constant name attribute_manager
 # wrong constant name convert
@@ -9525,7 +8878,7 @@
 # wrong constant name set_attrs
 # wrong constant name <static-init>
 # wrong constant name add_html
-# wrong constant name add_special
+# wrong constant name add_regexp_handling
 # wrong constant name add_word_pair
 # wrong constant name attribute
 # wrong constant name attributes
@@ -9533,7 +8886,7 @@
 # wrong constant name changed_attribute_by_name
 # wrong constant name convert_attrs
 # wrong constant name convert_html
-# wrong constant name convert_specials
+# wrong constant name convert_regexp_handlings
 # wrong constant name copy_string
 # wrong constant name display_attributes
 # wrong constant name flow
@@ -9541,7 +8894,7 @@
 # wrong constant name mask_protected_sequences
 # wrong constant name matching_word_pairs
 # wrong constant name protectable
-# wrong constant name special
+# wrong constant name regexp_handlings
 # wrong constant name split_into_flow
 # wrong constant name unmask_protected_sequences
 # wrong constant name word_pair_map
@@ -9549,7 +8902,7 @@
 # wrong constant name as_string
 # wrong constant name bitmap_for
 # wrong constant name each_name_of
-# wrong constant name special
+# wrong constant name regexp_handling
 # wrong constant name <static-init>
 # wrong constant name accept
 # wrong constant name <static-init>
@@ -9575,13 +8928,13 @@
 # wrong constant name <static-init>
 # wrong constant name <Class:InlineTag>
 # wrong constant name accept_document
-# wrong constant name add_special_RDOCLINK
-# wrong constant name add_special_TIDYLINK
+# wrong constant name add_regexp_handling_RDOCLINK
+# wrong constant name add_regexp_handling_TIDYLINK
 # wrong constant name add_tag
 # wrong constant name annotate
 # wrong constant name convert
 # wrong constant name convert_flow
-# wrong constant name convert_special
+# wrong constant name convert_regexp_handling
 # wrong constant name convert_string
 # wrong constant name ignore
 # wrong constant name in_tt?
@@ -9602,19 +8955,6 @@
 # wrong constant name members
 # wrong constant name <static-init>
 # wrong constant name gen_relative_url
-# uninitialized constant RDoc::Markup::FormatterTestCase::E
-# Did you mean?  RDoc::Markup::FormatterTestCase::E
-# uninitialized constant RDoc::Markup::FormatterTestCase::PASSTHROUGH_EXCEPTIONS
-# Did you mean?  RDoc::Markup::FormatterTestCase::PASSTHROUGH_EXCEPTIONS
-# uninitialized constant RDoc::Markup::FormatterTestCase::SIGNALS
-# Did you mean?  Signal
-#                RDoc::Markup::FormatterTestCase::SIGNALS
-# uninitialized constant RDoc::Markup::FormatterTestCase::TEARDOWN_METHODS
-# Did you mean?  RDoc::Markup::FormatterTestCase::TEARDOWN_METHODS
-# uninitialized constant RDoc::Markup::FormatterTestCase::UNDEFINED
-# Did you mean?  RDoc::Markup::FormatterTestCase::UNDEFINED
-# wrong constant name <static-init>
-# wrong constant name add_visitor_tests
 # wrong constant name ==
 # wrong constant name accept
 # wrong constant name <static-init>
@@ -9668,10 +9008,8 @@
 # wrong constant name <static-init>
 # wrong constant name <Class:Error>
 # uninitialized constant RDoc::Markup::Parser::MARKUP_FORMAT
-# Did you mean?  RDoc::Markup::Parser::MARKUP_FORMAT
 # wrong constant name <Class:ParseError>
 # uninitialized constant RDoc::Markup::Parser::TO_HTML_CHARACTERS
-# Did you mean?  RDoc::Markup::Parser::TO_HTML_CHARACTERS
 # wrong constant name build_heading
 # wrong constant name build_list
 # wrong constant name build_paragraph
@@ -9716,33 +9054,18 @@
 # wrong constant name push
 # wrong constant name text
 # wrong constant name <static-init>
-# wrong constant name accept
-# wrong constant name <static-init>
 # wrong constant name ==
 # wrong constant name initialize
 # wrong constant name text
 # wrong constant name text=
 # wrong constant name type
 # wrong constant name <static-init>
-# uninitialized constant RDoc::Markup::TextFormatterTestCase::E
-# Did you mean?  RDoc::Markup::TextFormatterTestCase::E
-# uninitialized constant RDoc::Markup::TextFormatterTestCase::PASSTHROUGH_EXCEPTIONS
-# Did you mean?  RDoc::Markup::TextFormatterTestCase::PASSTHROUGH_EXCEPTIONS
-# uninitialized constant RDoc::Markup::TextFormatterTestCase::SIGNALS
-# Did you mean?  Signal
-#                RDoc::Markup::TextFormatterTestCase::SIGNALS
-# uninitialized constant RDoc::Markup::TextFormatterTestCase::TEARDOWN_METHODS
-# Did you mean?  RDoc::Markup::TextFormatterTestCase::TEARDOWN_METHODS
-# uninitialized constant RDoc::Markup::TextFormatterTestCase::UNDEFINED
-# Did you mean?  RDoc::Markup::TextFormatterTestCase::UNDEFINED
+# wrong constant name accept
 # wrong constant name <static-init>
-# wrong constant name add_text_tests
 # wrong constant name <static-init>
 # wrong constant name <static-init>
 # uninitialized constant RDoc::Markup::ToHtml::MARKUP_FORMAT
-# Did you mean?  RDoc::Markup::ToHtml::MARKUP_FORMAT
 # uninitialized constant RDoc::Markup::ToHtml::TO_HTML_CHARACTERS
-# Did you mean?  RDoc::Markup::ToHtml::TO_HTML_CHARACTERS
 # wrong constant name accept_blank_line
 # wrong constant name accept_block_quote
 # wrong constant name accept_heading
@@ -9762,10 +9085,10 @@
 # wrong constant name from_path=
 # wrong constant name gen_url
 # wrong constant name handle_RDOCLINK
-# wrong constant name handle_special_HARD_BREAK
-# wrong constant name handle_special_HYPERLINK
-# wrong constant name handle_special_RDOCLINK
-# wrong constant name handle_special_TIDYLINK
+# wrong constant name handle_regexp_HARD_BREAK
+# wrong constant name handle_regexp_HYPERLINK
+# wrong constant name handle_regexp_RDOCLINK
+# wrong constant name handle_regexp_TIDYLINK
 # wrong constant name html_list_name
 # wrong constant name in_list_entry
 # wrong constant name init_tags
@@ -9778,32 +9101,26 @@
 # wrong constant name to_html
 # wrong constant name <static-init>
 # uninitialized constant RDoc::Markup::ToHtmlCrossref::LIST_TYPE_TO_HTML
-# Did you mean?  RDoc::Markup::ToHtmlCrossref::LIST_TYPE_TO_HTML
 # uninitialized constant RDoc::Markup::ToHtmlCrossref::MARKUP_FORMAT
-# Did you mean?  RDoc::Markup::ToHtmlCrossref::MARKUP_FORMAT
 # uninitialized constant RDoc::Markup::ToHtmlCrossref::TO_HTML_CHARACTERS
-# Did you mean?  RDoc::Markup::ToHtmlCrossref::TO_HTML_CHARACTERS
 # wrong constant name context
 # wrong constant name context=
 # wrong constant name cross_reference
-# wrong constant name handle_special_CROSSREF
+# wrong constant name handle_regexp_CROSSREF
 # wrong constant name initialize
 # wrong constant name link
 # wrong constant name show_hash
 # wrong constant name show_hash=
 # wrong constant name <static-init>
 # uninitialized constant RDoc::Markup::ToHtmlSnippet::LIST_TYPE_TO_HTML
-# Did you mean?  RDoc::Markup::ToHtmlSnippet::LIST_TYPE_TO_HTML
 # uninitialized constant RDoc::Markup::ToHtmlSnippet::MARKUP_FORMAT
-# Did you mean?  RDoc::Markup::ToHtmlSnippet::MARKUP_FORMAT
 # uninitialized constant RDoc::Markup::ToHtmlSnippet::TO_HTML_CHARACTERS
-# Did you mean?  RDoc::Markup::ToHtmlSnippet::TO_HTML_CHARACTERS
 # wrong constant name accept_raw
 # wrong constant name accept_rule
 # wrong constant name add_paragraph
 # wrong constant name character_limit
 # wrong constant name characters
-# wrong constant name handle_special_CROSSREF
+# wrong constant name handle_regexp_CROSSREF
 # wrong constant name initialize
 # wrong constant name mask
 # wrong constant name paragraph_limit
@@ -9837,17 +9154,17 @@
 # wrong constant name accept_verbatim
 # wrong constant name convert
 # wrong constant name end_accepting
-# wrong constant name handle_special_CROSSREF
-# wrong constant name handle_special_HARD_BREAK
-# wrong constant name handle_special_TIDYLINK
+# wrong constant name handle_regexp_CROSSREF
+# wrong constant name handle_regexp_HARD_BREAK
+# wrong constant name handle_regexp_TIDYLINK
 # wrong constant name initialize
 # wrong constant name res
 # wrong constant name start_accepting
 # wrong constant name <static-init>
 # wrong constant name gen_url
 # wrong constant name handle_rdoc_link
-# wrong constant name handle_special_RDOCLINK
-# wrong constant name handle_special_TIDYLINK
+# wrong constant name handle_regexp_RDOCLINK
+# wrong constant name handle_regexp_TIDYLINK
 # wrong constant name <static-init>
 # wrong constant name accept_blank_line
 # wrong constant name accept_block_quote
@@ -9863,8 +9180,8 @@
 # wrong constant name accept_verbatim
 # wrong constant name attributes
 # wrong constant name end_accepting
-# wrong constant name handle_special_HARD_BREAK
-# wrong constant name handle_special_SUPPRESSED_CROSSREF
+# wrong constant name handle_regexp_HARD_BREAK
+# wrong constant name handle_regexp_SUPPRESSED_CROSSREF
 # wrong constant name indent
 # wrong constant name indent=
 # wrong constant name init_tags
@@ -9987,7 +9304,6 @@
 # wrong constant name <static-init>
 # wrong constant name <Class:ClassMethods>
 # uninitialized constant YARD::Templates::Template::T
-# Did you mean?  T
 # wrong constant name class
 # wrong constant name class=
 # wrong constant name erb
@@ -10007,7 +9323,6 @@
 # wrong constant name yieldall
 # uninitialized constant YARD::Templates::Template::ClassMethods::S
 # uninitialized constant YARD::Templates::Template::ClassMethods::T
-# Did you mean?  T
 # wrong constant name find_file
 # wrong constant name find_nth_file
 # wrong constant name full_path

--- a/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -17,7 +17,11 @@ class Array
 
   def collect!(); end
 
+  def difference(*_); end
+
   def dig(*_); end
+
+  def filter!(); end
 
   def flatten!(*_); end
 
@@ -30,6 +34,8 @@ class Array
   def shelljoin(); end
 
   def to_h(); end
+
+  def union(*_); end
 end
 
 class Array
@@ -41,10 +47,6 @@ BasicObject::BasicObject = BasicObject
 
 class BasicObject
   extend ::T::Sig
-end
-
-class BasicSocket
-  def read_nonblock(len, str=T.unsafe(nil), exception: T.unsafe(nil)); end
 end
 
 class BasicSocket
@@ -69,13 +71,13 @@ class BigDecimal
 
   def self.mode(*_); end
 
+  def self.new(*args, **kwargs); end
+
   def self.save_exception_mode(); end
 
   def self.save_limit(); end
 
   def self.save_rounding_mode(); end
-
-  def self.ver(); end
 end
 
 module BigMath
@@ -94,6 +96,8 @@ class Binding
   def local_variable_set(_, _1); end
 
   def receiver(); end
+
+  def source_location(); end
 end
 
 class Binding
@@ -519,20 +523,6 @@ class Bundler::Installer
   def self.install(root, definition, options=T.unsafe(nil)); end
 end
 
-class Bundler::LockfileGenerator
-  def definition(); end
-
-  def generate!(); end
-
-  def initialize(definition); end
-
-  def out(); end
-end
-
-class Bundler::LockfileGenerator
-  def self.generate(definition); end
-end
-
 module Bundler::MatchPlatform
   extend ::T::Sig
 end
@@ -807,7 +797,7 @@ class Bundler::Settings::Mirror
 end
 
 class Bundler::Settings::Mirrors
-  def each(); end
+  def each(&blk); end
 
   def for(uri); end
 
@@ -1059,6 +1049,18 @@ class ClosedQueueError
   extend ::T::Sig
 end
 
+module Colorize::ClassMethods
+  extend ::T::Sig
+end
+
+module Colorize::InstanceMethods
+  extend ::T::Sig
+end
+
+module Colorize
+  extend ::T::Sig
+end
+
 module Comparable
   extend ::T::Sig
 end
@@ -1074,7 +1076,33 @@ end
 
 ConditionVariable = Thread::ConditionVariable
 
+module Coverage
+  extend ::T::Sig
+  def self.line_stub(file); end
+
+  def self.peek_result(); end
+
+  def self.running?(); end
+
+end
+
 class Data
+  extend ::T::Sig
+end
+
+class Date::Infinity
+  def initialize(d=T.unsafe(nil)); end
+end
+
+class Date::Infinity
+  extend ::T::Sig
+end
+
+class Date
+  extend ::T::Sig
+end
+
+class DateTime
   extend ::T::Sig
 end
 
@@ -1143,15 +1171,6 @@ module DidYouMean::Correctable
   extend ::T::Sig
 end
 
-class DidYouMean::DeprecatedIgnoredCallers
-  def +(*_); end
-
-  def <<(*_); end
-end
-
-class DidYouMean::DeprecatedIgnoredCallers
-end
-
 module DidYouMean::Jaro
   extend ::T::Sig
   def self.distance(str1, str2); end
@@ -1188,6 +1207,7 @@ class DidYouMean::MethodNameChecker
   def method_names(); end
 
   def receiver(); end
+  RB_RESERVED_WORDS = ::T.let(nil, ::T.untyped)
 end
 
 class DidYouMean::MethodNameChecker
@@ -1235,7 +1255,7 @@ class DidYouMean::VariableNameChecker
   def method_names(); end
 
   def name(); end
-  RB_PREDEFINED_OBJECTS = ::T.let(nil, ::T.untyped)
+  RB_RESERVED_WORDS = ::T.let(nil, ::T.untyped)
 end
 
 class DidYouMean::VariableNameChecker
@@ -1269,6 +1289,13 @@ module Digest
   extend ::T::Sig
 end
 
+class Dir
+  def children(); end
+
+  def each_child(); end
+
+end
+
 module Dir::Tmpname
   extend ::T::Sig
 end
@@ -1284,6 +1311,24 @@ class Dir
   def self.exists?(_); end
 
   def self.tmpdir(); end
+end
+
+module Docile
+  VERSION = ::T.let(nil, ::T.untyped)
+end
+
+module Docile::Execution
+  extend ::T::Sig
+end
+
+class Docile::FallbackContextProxy
+  NON_FALLBACK_METHODS = ::T.let(nil, ::T.untyped)
+  NON_PROXIED_INSTANCE_VARIABLES = ::T.let(nil, ::T.untyped)
+  NON_PROXIED_METHODS = ::T.let(nil, ::T.untyped)
+end
+
+module Docile
+  extend ::T::Sig
 end
 
 class EOFError
@@ -1438,13 +1483,15 @@ class EncodingError
 end
 
 module Enumerable
+  def chain(*_); end
+
   def chunk(); end
 
   def chunk_while(); end
 
   def each_entry(*_); end
 
-  def each_with_object(_); end
+  def filter(); end
 
   def grep_v(_); end
 
@@ -1469,8 +1516,38 @@ module Enumerable
   extend ::T::Sig
 end
 
+class Enumerator
+  def +(_); end
+
+  def each_with_index(); end
+
+end
+
+class Enumerator::ArithmeticSequence
+  def begin(); end
+
+  def each(&blk); end
+
+  def end(); end
+
+  def exclude_end?(); end
+
+  def last(*_); end
+
+  def step(); end
+end
+
+class Enumerator::ArithmeticSequence
+end
+
+class Enumerator::Chain
+end
+
+class Enumerator::Chain
+end
+
 class Enumerator::Generator
-  def each(*_); end
+  def each(*_, &blk); end
 
   def initialize(*_); end
 end
@@ -1517,10 +1594,6 @@ class Errno::EADDRNOTAVAIL
   extend ::T::Sig
 end
 
-class Errno::EADV
-  extend ::T::Sig
-end
-
 class Errno::EAFNOSUPPORT
   extend ::T::Sig
 end
@@ -1533,40 +1606,47 @@ class Errno::EALREADY
   extend ::T::Sig
 end
 
-Errno::EAUTH = Errno::NOERROR
+class Errno::EAUTH
+  Errno = ::T.let(nil, ::T.untyped)
+end
 
-class Errno::EBADE
-  extend ::T::Sig
+class Errno::EAUTH
+end
+
+class Errno::EBADARCH
+  Errno = ::T.let(nil, ::T.untyped)
+end
+
+class Errno::EBADARCH
+end
+
+class Errno::EBADEXEC
+  Errno = ::T.let(nil, ::T.untyped)
+end
+
+class Errno::EBADEXEC
 end
 
 class Errno::EBADF
   extend ::T::Sig
 end
 
-class Errno::EBADFD
-  extend ::T::Sig
+class Errno::EBADMACHO
+  Errno = ::T.let(nil, ::T.untyped)
+end
+
+class Errno::EBADMACHO
 end
 
 class Errno::EBADMSG
   extend ::T::Sig
 end
 
-class Errno::EBADR
-  extend ::T::Sig
+class Errno::EBADRPC
+  Errno = ::T.let(nil, ::T.untyped)
 end
 
-Errno::EBADRPC = Errno::NOERROR
-
-class Errno::EBADRQC
-  extend ::T::Sig
-end
-
-class Errno::EBADSLT
-  extend ::T::Sig
-end
-
-class Errno::EBFONT
-  extend ::T::Sig
+class Errno::EBADRPC
 end
 
 class Errno::EBUSY
@@ -1580,14 +1660,6 @@ end
 Errno::ECAPMODE = Errno::NOERROR
 
 class Errno::ECHILD
-  extend ::T::Sig
-end
-
-class Errno::ECHRNG
-  extend ::T::Sig
-end
-
-class Errno::ECOMM
   extend ::T::Sig
 end
 
@@ -1607,10 +1679,17 @@ class Errno::EDEADLK
   extend ::T::Sig
 end
 
-Errno::EDEADLOCK = Errno::EDEADLK
+Errno::EDEADLOCK = Errno::NOERROR
 
 class Errno::EDESTADDRREQ
   extend ::T::Sig
+end
+
+class Errno::EDEVERR
+  Errno = ::T.let(nil, ::T.untyped)
+end
+
+class Errno::EDEVERR
 end
 
 class Errno::EDOM
@@ -1618,10 +1697,6 @@ class Errno::EDOM
 end
 
 Errno::EDOOFUS = Errno::NOERROR
-
-class Errno::EDOTDOT
-  extend ::T::Sig
-end
 
 class Errno::EDQUOT
   extend ::T::Sig
@@ -1639,17 +1714,18 @@ class Errno::EFBIG
   extend ::T::Sig
 end
 
-Errno::EFTYPE = Errno::NOERROR
+class Errno::EFTYPE
+  Errno = ::T.let(nil, ::T.untyped)
+end
+
+class Errno::EFTYPE
+end
 
 class Errno::EHOSTDOWN
   extend ::T::Sig
 end
 
 class Errno::EHOSTUNREACH
-  extend ::T::Sig
-end
-
-class Errno::EHWPOISON
   extend ::T::Sig
 end
 
@@ -1687,67 +1763,14 @@ class Errno::EISDIR
   extend ::T::Sig
 end
 
-class Errno::EISNAM
-  extend ::T::Sig
+class Errno::ELAST
+  Errno = ::T.let(nil, ::T.untyped)
 end
 
-class Errno::EKEYEXPIRED
-  extend ::T::Sig
-end
-
-class Errno::EKEYREJECTED
-  extend ::T::Sig
-end
-
-class Errno::EKEYREVOKED
-  extend ::T::Sig
-end
-
-class Errno::EL2HLT
-  extend ::T::Sig
-end
-
-class Errno::EL2NSYNC
-  extend ::T::Sig
-end
-
-class Errno::EL3HLT
-  extend ::T::Sig
-end
-
-class Errno::EL3RST
-  extend ::T::Sig
-end
-
-class Errno::ELIBACC
-  extend ::T::Sig
-end
-
-class Errno::ELIBBAD
-  extend ::T::Sig
-end
-
-class Errno::ELIBEXEC
-  extend ::T::Sig
-end
-
-class Errno::ELIBMAX
-  extend ::T::Sig
-end
-
-class Errno::ELIBSCN
-  extend ::T::Sig
-end
-
-class Errno::ELNRNG
-  extend ::T::Sig
+class Errno::ELAST
 end
 
 class Errno::ELOOP
-  extend ::T::Sig
-end
-
-class Errno::EMEDIUMTYPE
   extend ::T::Sig
 end
 
@@ -1771,11 +1794,12 @@ class Errno::ENAMETOOLONG
   extend ::T::Sig
 end
 
-class Errno::ENAVAIL
-  extend ::T::Sig
+class Errno::ENEEDAUTH
+  Errno = ::T.let(nil, ::T.untyped)
 end
 
-Errno::ENEEDAUTH = Errno::NOERROR
+class Errno::ENEEDAUTH
+end
 
 class Errno::ENETDOWN
   extend ::T::Sig
@@ -1793,17 +1817,14 @@ class Errno::ENFILE
   extend ::T::Sig
 end
 
-class Errno::ENOANO
-  extend ::T::Sig
+class Errno::ENOATTR
+  Errno = ::T.let(nil, ::T.untyped)
 end
 
-Errno::ENOATTR = Errno::NOERROR
+class Errno::ENOATTR
+end
 
 class Errno::ENOBUFS
-  extend ::T::Sig
-end
-
-class Errno::ENOCSI
   extend ::T::Sig
 end
 
@@ -1823,19 +1844,11 @@ class Errno::ENOEXEC
   extend ::T::Sig
 end
 
-class Errno::ENOKEY
-  extend ::T::Sig
-end
-
 class Errno::ENOLCK
   extend ::T::Sig
 end
 
 class Errno::ENOLINK
-  extend ::T::Sig
-end
-
-class Errno::ENOMEDIUM
   extend ::T::Sig
 end
 
@@ -1847,12 +1860,11 @@ class Errno::ENOMSG
   extend ::T::Sig
 end
 
-class Errno::ENONET
-  extend ::T::Sig
+class Errno::ENOPOLICY
+  Errno = ::T.let(nil, ::T.untyped)
 end
 
-class Errno::ENOPKG
-  extend ::T::Sig
+class Errno::ENOPOLICY
 end
 
 class Errno::ENOPROTOOPT
@@ -1893,10 +1905,6 @@ class Errno::ENOTEMPTY
   extend ::T::Sig
 end
 
-class Errno::ENOTNAM
-  extend ::T::Sig
-end
-
 class Errno::ENOTRECOVERABLE
   extend ::T::Sig
 end
@@ -1905,13 +1913,14 @@ class Errno::ENOTSOCK
   extend ::T::Sig
 end
 
-Errno::ENOTSUP = Errno::EOPNOTSUPP
-
-class Errno::ENOTTY
-  extend ::T::Sig
+class Errno::ENOTSUP
+  Errno = ::T.let(nil, ::T.untyped)
 end
 
-class Errno::ENOTUNIQ
+class Errno::ENOTSUP
+end
+
+class Errno::ENOTTY
   extend ::T::Sig
 end
 
@@ -1943,13 +1952,33 @@ class Errno::EPIPE
   extend ::T::Sig
 end
 
-Errno::EPROCLIM = Errno::NOERROR
+class Errno::EPROCLIM
+  Errno = ::T.let(nil, ::T.untyped)
+end
 
-Errno::EPROCUNAVAIL = Errno::NOERROR
+class Errno::EPROCLIM
+end
 
-Errno::EPROGMISMATCH = Errno::NOERROR
+class Errno::EPROCUNAVAIL
+  Errno = ::T.let(nil, ::T.untyped)
+end
 
-Errno::EPROGUNAVAIL = Errno::NOERROR
+class Errno::EPROCUNAVAIL
+end
+
+class Errno::EPROGMISMATCH
+  Errno = ::T.let(nil, ::T.untyped)
+end
+
+class Errno::EPROGMISMATCH
+end
+
+class Errno::EPROGUNAVAIL
+  Errno = ::T.let(nil, ::T.untyped)
+end
+
+class Errno::EPROGUNAVAIL
+end
 
 class Errno::EPROTO
   extend ::T::Sig
@@ -1963,11 +1992,16 @@ class Errno::EPROTOTYPE
   extend ::T::Sig
 end
 
-class Errno::ERANGE
-  extend ::T::Sig
+class Errno::EPWROFF
+  Errno = ::T.let(nil, ::T.untyped)
 end
 
-class Errno::EREMCHG
+class Errno::EPWROFF
+end
+
+Errno::EQFULL = Errno::ELAST
+
+class Errno::ERANGE
   extend ::T::Sig
 end
 
@@ -1975,23 +2009,23 @@ class Errno::EREMOTE
   extend ::T::Sig
 end
 
-class Errno::EREMOTEIO
-  extend ::T::Sig
-end
-
-class Errno::ERESTART
-  extend ::T::Sig
-end
-
-class Errno::ERFKILL
-  extend ::T::Sig
-end
-
 class Errno::EROFS
   extend ::T::Sig
 end
 
-Errno::ERPCMISMATCH = Errno::NOERROR
+class Errno::ERPCMISMATCH
+  Errno = ::T.let(nil, ::T.untyped)
+end
+
+class Errno::ERPCMISMATCH
+end
+
+class Errno::ESHLIBVERS
+  Errno = ::T.let(nil, ::T.untyped)
+end
+
+class Errno::ESHLIBVERS
+end
 
 class Errno::ESHUTDOWN
   extend ::T::Sig
@@ -2009,15 +2043,7 @@ class Errno::ESRCH
   extend ::T::Sig
 end
 
-class Errno::ESRMNT
-  extend ::T::Sig
-end
-
 class Errno::ESTALE
-  extend ::T::Sig
-end
-
-class Errno::ESTRPIPE
   extend ::T::Sig
 end
 
@@ -2037,23 +2063,11 @@ class Errno::ETXTBSY
   extend ::T::Sig
 end
 
-class Errno::EUCLEAN
-  extend ::T::Sig
-end
-
-class Errno::EUNATCH
-  extend ::T::Sig
-end
-
 class Errno::EUSERS
   extend ::T::Sig
 end
 
 class Errno::EXDEV
-  extend ::T::Sig
-end
-
-class Errno::EXFULL
   extend ::T::Sig
 end
 
@@ -2088,15 +2102,23 @@ class Etc::Group
   extend ::Enumerable
   def self.[](*_); end
 
-  def self.each(); end
+  def self.each(&blk); end
 
   def self.members(); end
 end
 
 class Etc::Passwd
+  def change(); end
+
+  def change=(_); end
+
   def dir(); end
 
   def dir=(_); end
+
+  def expire(); end
+
+  def expire=(_); end
 
   def gecos(); end
 
@@ -2118,6 +2140,10 @@ class Etc::Passwd
 
   def shell=(_); end
 
+  def uclass(); end
+
+  def uclass=(_); end
+
   def uid(); end
 
   def uid=(_); end
@@ -2128,7 +2154,7 @@ class Etc::Passwd
   extend ::Enumerable
   def self.[](*_); end
 
-  def self.each(); end
+  def self.each(&blk); end
 
   def self.members(); end
 end
@@ -2356,6 +2382,8 @@ class FileUtils::Entry_
 
   def initialize(a, b=T.unsafe(nil), deref=T.unsafe(nil)); end
 
+  def link(dest); end
+
   def lstat(); end
 
   def lstat!(); end
@@ -2466,6 +2494,8 @@ module FileUtils
 
   def self.cp(src, dest, preserve: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
 
+  def self.cp_lr(src, dest, noop: T.unsafe(nil), verbose: T.unsafe(nil), dereference_root: T.unsafe(nil), remove_destination: T.unsafe(nil)); end
+
   def self.getwd(); end
 
   def self.have_option?(mid, opt); end
@@ -2475,6 +2505,8 @@ module FileUtils
   def self.install(src, dest, mode: T.unsafe(nil), owner: T.unsafe(nil), group: T.unsafe(nil), preserve: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
 
   def self.link(src, dest, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
+
+  def self.link_entry(src, dest, dereference_root=T.unsafe(nil), remove_destination=T.unsafe(nil)); end
 
   def self.ln(src, dest, force: T.unsafe(nil), noop: T.unsafe(nil), verbose: T.unsafe(nil)); end
 
@@ -2539,6 +2571,34 @@ class FloatDomainError
   extend ::T::Sig
 end
 
+module Forwardable
+  def def_delegator(accessor, method, ali=T.unsafe(nil)); end
+
+  def def_delegators(accessor, *methods); end
+
+  def def_instance_delegator(accessor, method, ali=T.unsafe(nil)); end
+
+  def def_instance_delegators(accessor, *methods); end
+
+  def delegate(hash); end
+
+  def instance_delegate(hash); end
+  VERSION = ::T.let(nil, ::T.untyped)
+end
+
+module Forwardable
+  extend ::T::Sig
+  def self._compile_method(src, file, line); end
+
+  def self._delegator_method(obj, accessor, method, ali); end
+
+  def self._valid_method?(method); end
+
+  def self.debug(); end
+
+  def self.debug=(debug); end
+end
+
 class FrozenError
 end
 
@@ -2560,6 +2620,8 @@ module GC
   def self.stress=(stress); end
 
   def self.verify_internal_consistency(); end
+
+  def self.verify_transient_heap_internal_consistency(); end
 end
 
 module Gem
@@ -2578,7 +2640,7 @@ class Gem::AvailableSet
 
   def all_specs(); end
 
-  def each(); end
+  def each(&blk); end
 
   def each_spec(); end
 
@@ -2699,8 +2761,6 @@ end
 class Gem::BasicSpecification
   extend ::T::Sig
   def self.default_specifications_dir(); end
-
-  def self.upstream_default_specifications_dir(); end
 end
 
 module Gem::BundlerVersionFinder
@@ -2724,6 +2784,7 @@ Gem::Cache = Gem::SourceIndex
 class Gem::Command
   include ::Gem::UserInteraction
   include ::Gem::DefaultUserInteraction
+  include ::Gem::Text
   def add_extra_args(args); end
 
   def add_option(*opts, &handler); end
@@ -2820,6 +2881,7 @@ end
 class Gem::ConfigFile
   include ::Gem::UserInteraction
   include ::Gem::DefaultUserInteraction
+  include ::Gem::Text
   def ==(other); end
 
   def [](key); end
@@ -2942,6 +3004,7 @@ class Gem::ConsoleUI
 end
 
 module Gem::DefaultUserInteraction
+  include ::Gem::Text
   def ui(); end
 
   def ui=(new_ui); end
@@ -3031,6 +3094,7 @@ end
 class Gem::DependencyInstaller
   include ::Gem::UserInteraction
   include ::Gem::DefaultUserInteraction
+  include ::Gem::Text
   def _deprecated_add_found_dependencies(to_do, dependency_list); end
 
   def _deprecated_gather_dependencies(); end
@@ -3175,6 +3239,7 @@ end
 class Gem::Ext::Builder
   include ::Gem::UserInteraction
   include ::Gem::DefaultUserInteraction
+  include ::Gem::Text
   def build_args(); end
 
   def build_args=(build_args); end
@@ -3295,6 +3360,7 @@ end
 class Gem::Installer
   include ::Gem::UserInteraction
   include ::Gem::DefaultUserInteraction
+  include ::Gem::Text
   def _deprecated_extension_build_error(build_dir, output, backtrace=T.unsafe(nil)); end
 
   def app_script_text(bin_file_name); end
@@ -3375,7 +3441,7 @@ class Gem::Installer
 
   def verify_gem_home(unpack=T.unsafe(nil)); end
 
-  def verify_spec_name(); end
+  def verify_spec(); end
 
   def windows_stub_script(bindir, bin_file_name); end
 
@@ -3425,7 +3491,7 @@ class Gem::Licenses
 end
 
 class Gem::List
-  def each(); end
+  def each(&blk); end
 
   def initialize(value=T.unsafe(nil), tail=T.unsafe(nil)); end
 
@@ -3519,6 +3585,7 @@ end
 class Gem::Package
   include ::Gem::UserInteraction
   include ::Gem::DefaultUserInteraction
+  include ::Gem::Text
   def add_checksums(tar); end
 
   def add_contents(tar); end
@@ -3755,7 +3822,7 @@ class Gem::Package::TarReader
   include ::Enumerable
   def close(); end
 
-  def each(); end
+  def each(&blk); end
 
   def each_entry(); end
 
@@ -3968,6 +4035,7 @@ end
 class Gem::RemoteFetcher
   include ::Gem::UserInteraction
   include ::Gem::DefaultUserInteraction
+  include ::Gem::Text
   def cache_update_path(uri, path=T.unsafe(nil), update=T.unsafe(nil)); end
 
   def close_all(); end
@@ -4025,6 +4093,7 @@ end
 class Gem::Request
   include ::Gem::UserInteraction
   include ::Gem::DefaultUserInteraction
+  include ::Gem::Text
   def cert_files(); end
 
   def connection_for(uri); end
@@ -4082,6 +4151,7 @@ end
 class Gem::Request
   extend ::Gem::UserInteraction
   extend ::Gem::DefaultUserInteraction
+  extend ::Gem::Text
   def self.configure_connection_for_https(connection, cert_files); end
 
   def self.create_with_proxy(uri, request_class, last_modified, proxy); end
@@ -4782,7 +4852,7 @@ class Gem::Resolver::Molinillo::DependencyGraph
 
   def detach_vertex_named(name); end
 
-  def each(); end
+  def each(&blk); end
 
   def rewind_to(tag); end
 
@@ -4900,7 +4970,7 @@ class Gem::Resolver::Molinillo::DependencyGraph::Log
 
   def detach_vertex_named(graph, name); end
 
-  def each(); end
+  def each(&blk); end
 
   def pop!(graph); end
 
@@ -5205,7 +5275,7 @@ class Gem::Resolver::RequirementList
   include ::Enumerable
   def add(req); end
 
-  def each(); end
+  def each(&blk); end
 
   def empty?(); end
 
@@ -5377,11 +5447,19 @@ end
 class Gem::Security::KEY_ALGORITHM
   def d(); end
 
+  def d=(d); end
+
   def dmp1(); end
+
+  def dmp1=(dmp1); end
 
   def dmq1(); end
 
+  def dmq1=(dmq1); end
+
   def e(); end
+
+  def e=(e); end
 
   def export(*_); end
 
@@ -5389,9 +5467,15 @@ class Gem::Security::KEY_ALGORITHM
 
   def iqmp(); end
 
+  def iqmp=(iqmp); end
+
   def n(); end
 
+  def n=(n); end
+
   def p(); end
+
+  def p=(p); end
 
   def params(); end
 
@@ -5410,6 +5494,8 @@ class Gem::Security::KEY_ALGORITHM
   def public_key(); end
 
   def q(); end
+
+  def q=(q); end
 
   def set_crt_params(_, _1, _2); end
 
@@ -5441,6 +5527,7 @@ end
 class Gem::Security::Policy
   include ::Gem::UserInteraction
   include ::Gem::DefaultUserInteraction
+  include ::Gem::Text
   def check_cert(signer, issuer, time); end
 
   def check_chain(chain, time); end
@@ -5494,6 +5581,7 @@ end
 class Gem::Security::Signer
   include ::Gem::UserInteraction
   include ::Gem::DefaultUserInteraction
+  include ::Gem::Text
   def cert_chain(); end
 
   def cert_chain=(cert_chain); end
@@ -5731,7 +5819,7 @@ class Gem::SourceList
 
   def delete(source); end
 
-  def each(); end
+  def each(&blk); end
 
   def each_source(&b); end
 
@@ -6156,7 +6244,7 @@ class Gem::Specification
 
   def self.dirs=(dirs); end
 
-  def self.each(); end
+  def self.each(&blk); end
 
   def self.each_gemspec(dirs); end
 
@@ -6398,6 +6486,7 @@ end
 
 module Gem::UserInteraction
   include ::Gem::DefaultUserInteraction
+  include ::Gem::Text
   def alert(statement, question=T.unsafe(nil)); end
 
   def alert_error(statement, question=T.unsafe(nil)); end
@@ -6662,12 +6751,6 @@ module Gem
 
   def self.ui(); end
 
-  def self.upstream_default_bindir(); end
-
-  def self.upstream_default_dir(); end
-
-  def self.upstream_default_path(); end
-
   def self.use_gemdeps(path=T.unsafe(nil)); end
 
   def self.use_paths(home, *paths); end
@@ -6705,11 +6788,13 @@ class Hash
 
   def fetch_values(*_); end
 
+  def filter!(); end
+
   def flatten(*_); end
 
   def index(_); end
 
-  def merge!(_); end
+  def merge!(*_); end
 
   def replace(_); end
 
@@ -6727,7 +6812,7 @@ class Hash
 
   def transform_values!(); end
 
-  def update(_); end
+  def update(*_); end
 end
 
 class Hash
@@ -7161,8 +7246,6 @@ module JSON
 end
 
 module Kernel
-  def class(); end
-
   def gem(dep, *reqs); end
 
   def itself(); end
@@ -7172,6 +7255,8 @@ module Kernel
   def pretty_inspect(); end
 
   def respond_to?(*_); end
+
+  def then(); end
 
   def yield_self(); end
 end
@@ -7244,7 +7329,11 @@ module Math
 end
 
 class Method
+  def <<(_); end
+
   def ===(*_); end
+
+  def >>(_); end
 
   def [](*_); end
 
@@ -7275,306 +7364,10 @@ class Method
   extend ::T::Sig
 end
 
-module Minitest::Assertions
-  def _synchronize(); end
-
-  def assert(test, msg=T.unsafe(nil)); end
-
-  def assert_empty(obj, msg=T.unsafe(nil)); end
-
-  def assert_equal(exp, act, msg=T.unsafe(nil)); end
-
-  def assert_in_delta(exp, act, delta=T.unsafe(nil), msg=T.unsafe(nil)); end
-
-  def assert_in_epsilon(a, b, epsilon=T.unsafe(nil), msg=T.unsafe(nil)); end
-
-  def assert_includes(collection, obj, msg=T.unsafe(nil)); end
-
-  def assert_instance_of(cls, obj, msg=T.unsafe(nil)); end
-
-  def assert_kind_of(cls, obj, msg=T.unsafe(nil)); end
-
-  def assert_match(matcher, obj, msg=T.unsafe(nil)); end
-
-  def assert_mock(mock); end
-
-  def assert_nil(obj, msg=T.unsafe(nil)); end
-
-  def assert_operator(o1, op, o2=T.unsafe(nil), msg=T.unsafe(nil)); end
-
-  def assert_output(stdout=T.unsafe(nil), stderr=T.unsafe(nil)); end
-
-  def assert_predicate(o1, op, msg=T.unsafe(nil)); end
-
-  def assert_raises(*exp); end
-
-  def assert_respond_to(obj, meth, msg=T.unsafe(nil)); end
-
-  def assert_same(exp, act, msg=T.unsafe(nil)); end
-
-  def assert_send(send_ary, m=T.unsafe(nil)); end
-
-  def assert_silent(); end
-
-  def assert_throws(sym, msg=T.unsafe(nil)); end
-
-  def capture_io(); end
-
-  def capture_subprocess_io(); end
-
-  def diff(exp, act); end
-
-  def exception_details(e, msg); end
-
-  def flunk(msg=T.unsafe(nil)); end
-
-  def message(msg=T.unsafe(nil), ending=T.unsafe(nil), &default); end
-
-  def mu_pp(obj); end
-
-  def mu_pp_for_diff(obj); end
-
-  def pass(_msg=T.unsafe(nil)); end
-
-  def refute(test, msg=T.unsafe(nil)); end
-
-  def refute_empty(obj, msg=T.unsafe(nil)); end
-
-  def refute_equal(exp, act, msg=T.unsafe(nil)); end
-
-  def refute_in_delta(exp, act, delta=T.unsafe(nil), msg=T.unsafe(nil)); end
-
-  def refute_in_epsilon(a, b, epsilon=T.unsafe(nil), msg=T.unsafe(nil)); end
-
-  def refute_includes(collection, obj, msg=T.unsafe(nil)); end
-
-  def refute_instance_of(cls, obj, msg=T.unsafe(nil)); end
-
-  def refute_kind_of(cls, obj, msg=T.unsafe(nil)); end
-
-  def refute_match(matcher, obj, msg=T.unsafe(nil)); end
-
-  def refute_nil(obj, msg=T.unsafe(nil)); end
-
-  def refute_operator(o1, op, o2=T.unsafe(nil), msg=T.unsafe(nil)); end
-
-  def refute_predicate(o1, op, msg=T.unsafe(nil)); end
-
-  def refute_respond_to(obj, meth, msg=T.unsafe(nil)); end
-
-  def refute_same(exp, act, msg=T.unsafe(nil)); end
-
-  def skip(msg=T.unsafe(nil), bt=T.unsafe(nil)); end
-
-  def skipped?(); end
-  E = ::T.let(nil, ::T.untyped)
-  UNDEFINED = ::T.let(nil, ::T.untyped)
-end
-
-module Minitest::Assertions
-  extend ::T::Sig
-  def self.diff(); end
-
-  def self.diff=(o); end
-end
-
-module Minitest::Expectations
-  def must_be(*args); end
-
-  def must_be_close_to(*args); end
-
-  def must_be_empty(*args); end
-
-  def must_be_instance_of(*args); end
-
-  def must_be_kind_of(*args); end
-
-  def must_be_nil(*args); end
-
-  def must_be_same_as(*args); end
-
-  def must_be_silent(*args); end
-
-  def must_be_within_delta(*args); end
-
-  def must_be_within_epsilon(*args); end
-
-  def must_equal(*args); end
-
-  def must_include(*args); end
-
-  def must_match(*args); end
-
-  def must_output(*args); end
-
-  def must_raise(*args); end
-
-  def must_respond_to(*args); end
-
-  def must_throw(*args); end
-
-  def wont_be(*args); end
-
-  def wont_be_close_to(*args); end
-
-  def wont_be_empty(*args); end
-
-  def wont_be_instance_of(*args); end
-
-  def wont_be_kind_of(*args); end
-
-  def wont_be_nil(*args); end
-
-  def wont_be_same_as(*args); end
-
-  def wont_be_within_delta(*args); end
-
-  def wont_be_within_epsilon(*args); end
-
-  def wont_equal(*args); end
-
-  def wont_include(*args); end
-
-  def wont_match(*args); end
-
-  def wont_respond_to(*args); end
-end
-
-module Minitest::Expectations
-  extend ::T::Sig
-end
-
-module Minitest::Guard
-  def jruby?(platform=T.unsafe(nil)); end
-
-  def maglev?(platform=T.unsafe(nil)); end
-
-  def mri?(platform=T.unsafe(nil)); end
-
-  def rubinius?(platform=T.unsafe(nil)); end
-
-  def windows?(platform=T.unsafe(nil)); end
-end
-
-module Minitest::Guard
-  extend ::T::Sig
-end
-
-class Minitest::Runnable
-  def assertions(); end
-
-  def assertions=(assertions); end
-
-  def failure(); end
-
-  def failures(); end
-
-  def failures=(failures); end
-
-  def initialize(name); end
-
-  def marshal_dump(); end
-
-  def marshal_load(ary); end
-
-  def name(); end
-
-  def name=(o); end
-
-  def passed?(); end
-
-  def result_code(); end
-
-  def run(); end
-
-  def skipped?(); end
-  SIGNALS = ::T.let(nil, ::T.untyped)
-end
-
-class Minitest::Runnable
-  def self.inherited(klass); end
-
-  def self.methods_matching(re); end
-
-  def self.on_signal(name, action); end
-
-  def self.reset(); end
-
-  def self.run(reporter, options=T.unsafe(nil)); end
-
-  def self.run_one_method(klass, method_name, reporter); end
-
-  def self.runnable_methods(); end
-
-  def self.runnables(); end
-
-  def self.with_info_handler(reporter, &block); end
-end
-
-class Minitest::Test
-  include ::Minitest::Assertions
-  include ::Minitest::Test::LifecycleHooks
-  include ::Minitest::Guard
-  def capture_exceptions(); end
-
-  def error?(); end
-
-  def location(); end
-
-  def time(); end
-
-  def time=(time); end
-
-  def time_it(); end
-
-  def with_info_handler(&block); end
-  PASSTHROUGH_EXCEPTIONS = ::T.let(nil, ::T.untyped)
-  TEARDOWN_METHODS = ::T.let(nil, ::T.untyped)
-end
-
-module Minitest::Test::LifecycleHooks
-  def after_setup(); end
-
-  def after_teardown(); end
-
-  def before_setup(); end
-
-  def before_teardown(); end
-
-  def setup(); end
-
-  def teardown(); end
-end
-
-module Minitest::Test::LifecycleHooks
-  extend ::T::Sig
-end
-
-class Minitest::Test
-  extend ::Minitest::Guard
-  def self.i_suck_and_my_tests_are_order_dependent!(); end
-
-  def self.io_lock(); end
-
-  def self.io_lock=(io_lock); end
-
-  def self.make_my_diffs_pretty!(); end
-
-  def self.parallelize_me!(); end
-
-  def self.test_order(); end
-end
-
-class Minitest::Unit::TestCase
-end
-
-class Minitest::Unit::TestCase
-end
+Methods = T::Private::Methods
 
 class Module
   def deprecate_constant(*_); end
-
-  def infect_an_assertion(meth, new_name, dont_flip=T.unsafe(nil)); end
 
   def undef_method(*_); end
 end
@@ -7702,10 +7495,9 @@ class Numeric
 end
 
 class Object
-  include ::Minitest::Expectations
   include ::PP::ObjectMixin
   include ::JSON::Ext::Generator::GeneratorMethods::Object
-  def stub(name, val_or_callable, *block_args); end
+  def to_yaml(options=T.unsafe(nil)); end
   ARGF = ::T.let(nil, ::T.untyped)
   ARGV = ::T.let(nil, ::T.untyped)
   CROSS_COMPILING = ::T.let(nil, ::T.untyped)
@@ -7730,6 +7522,7 @@ end
 
 class Object
   extend ::T::Sig
+  def self.yaml_tag(url); end
 end
 
 class ObjectSpace::WeakMap
@@ -7737,7 +7530,7 @@ class ObjectSpace::WeakMap
 
   def []=(_, _1); end
 
-  def each(); end
+  def each(&blk); end
 
   def each_key(); end
 
@@ -8083,7 +7876,7 @@ class OptionParser::Switch
 
   def desc(); end
 
-  def initialize(pattern=T.unsafe(nil), conv=T.unsafe(nil), short=T.unsafe(nil), long=T.unsafe(nil), arg=T.unsafe(nil), desc=T.unsafe(nil), block=T.unsafe(nil)); end
+  def initialize(pattern=T.unsafe(nil), conv=T.unsafe(nil), short=T.unsafe(nil), long=T.unsafe(nil), arg=T.unsafe(nil), desc=T.unsafe(nil), block=T.unsafe(nil), &_block); end
 
   def long(); end
 
@@ -8171,7 +7964,11 @@ class Pathname
 end
 
 class Proc
+  def <<(_); end
+
   def ===(*_); end
+
+  def >>(_); end
 
   def [](*_); end
 
@@ -8184,6 +7981,12 @@ end
 
 class Proc
   extend ::T::Sig
+end
+
+module Process
+  CLOCK_MONOTONIC_RAW_APPROX = ::T.let(nil, ::T.untyped)
+  CLOCK_UPTIME_RAW = ::T.let(nil, ::T.untyped)
+  CLOCK_UPTIME_RAW_APPROX = ::T.let(nil, ::T.untyped)
 end
 
 module Process::GID
@@ -8241,46 +8044,808 @@ module Process
 
 end
 
+module Psych
+  LIBYAML_VERSION = ::T.let(nil, ::T.untyped)
+  VERSION = ::T.let(nil, ::T.untyped)
+end
+
+class Psych::BadAlias
+end
+
+class Psych::BadAlias
+end
+
+class Psych::ClassLoader
+  def big_decimal(); end
+
+  def complex(); end
+
+  def date(); end
+
+  def date_time(); end
+
+  def exception(); end
+
+  def load(klassname); end
+
+  def object(); end
+
+  def psych_omap(); end
+
+  def psych_set(); end
+
+  def range(); end
+
+  def rational(); end
+
+  def regexp(); end
+
+  def struct(); end
+
+  def symbol(); end
+
+  def symbolize(sym); end
+  BIG_DECIMAL = ::T.let(nil, ::T.untyped)
+  CACHE = ::T.let(nil, ::T.untyped)
+  COMPLEX = ::T.let(nil, ::T.untyped)
+  DATE = ::T.let(nil, ::T.untyped)
+  DATE_TIME = ::T.let(nil, ::T.untyped)
+  EXCEPTION = ::T.let(nil, ::T.untyped)
+  OBJECT = ::T.let(nil, ::T.untyped)
+  PSYCH_OMAP = ::T.let(nil, ::T.untyped)
+  PSYCH_SET = ::T.let(nil, ::T.untyped)
+  RANGE = ::T.let(nil, ::T.untyped)
+  RATIONAL = ::T.let(nil, ::T.untyped)
+  REGEXP = ::T.let(nil, ::T.untyped)
+  STRUCT = ::T.let(nil, ::T.untyped)
+  SYMBOL = ::T.let(nil, ::T.untyped)
+end
+
+class Psych::ClassLoader::Restricted
+  def initialize(classes, symbols); end
+end
+
+class Psych::ClassLoader::Restricted
+end
+
+class Psych::ClassLoader
+end
+
+class Psych::Coder
+  def [](k); end
+
+  def []=(k, v); end
+
+  def add(k, v); end
+
+  def implicit(); end
+
+  def implicit=(implicit); end
+
+  def initialize(tag); end
+
+  def map(tag=T.unsafe(nil), style=T.unsafe(nil)); end
+
+  def map=(map); end
+
+  def object(); end
+
+  def object=(object); end
+
+  def represent_map(tag, map); end
+
+  def represent_object(tag, obj); end
+
+  def represent_scalar(tag, value); end
+
+  def represent_seq(tag, list); end
+
+  def scalar(*args); end
+
+  def scalar=(value); end
+
+  def seq(); end
+
+  def seq=(list); end
+
+  def style(); end
+
+  def style=(style); end
+
+  def tag(); end
+
+  def tag=(tag); end
+
+  def type(); end
+end
+
+class Psych::Coder
+end
+
+class Psych::DisallowedClass
+  def initialize(klass_name); end
+end
+
+class Psych::DisallowedClass
+end
+
+class Psych::Emitter
+  def alias(_); end
+
+  def canonical(); end
+
+  def canonical=(canonical); end
+
+  def end_document(_); end
+
+  def indentation(); end
+
+  def indentation=(indentation); end
+
+  def initialize(*_); end
+
+  def line_width(); end
+
+  def line_width=(line_width); end
+
+  def scalar(_, _1, _2, _3, _4, _5); end
+
+  def start_document(_, _1, _2); end
+
+  def start_mapping(_, _1, _2, _3); end
+
+  def start_sequence(_, _1, _2, _3); end
+
+  def start_stream(_); end
+end
+
+class Psych::Emitter
+end
+
+class Psych::Exception
+end
+
+class Psych::Exception
+end
+
+class Psych::Handler
+  def alias(anchor); end
+
+  def empty(); end
+
+  def end_document(implicit); end
+
+  def end_mapping(); end
+
+  def end_sequence(); end
+
+  def end_stream(); end
+
+  def event_location(start_line, start_column, end_line, end_column); end
+
+  def scalar(value, anchor, tag, plain, quoted, style); end
+
+  def start_document(version, tag_directives, implicit); end
+
+  def start_mapping(anchor, tag, implicit, style); end
+
+  def start_sequence(anchor, tag, implicit, style); end
+
+  def start_stream(encoding); end
+
+  def streaming?(); end
+  EVENTS = ::T.let(nil, ::T.untyped)
+  OPTIONS = ::T.let(nil, ::T.untyped)
+end
+
+class Psych::Handler::DumperOptions
+  def canonical(); end
+
+  def canonical=(canonical); end
+
+  def indentation(); end
+
+  def indentation=(indentation); end
+
+  def line_width(); end
+
+  def line_width=(line_width); end
+end
+
+class Psych::Handler::DumperOptions
+end
+
+class Psych::Handler
+end
+
+module Psych::Handlers
+end
+
+class Psych::Handlers::DocumentStream
+  def initialize(&block); end
+end
+
+class Psych::Handlers::DocumentStream
+end
+
+module Psych::Handlers
+  extend ::T::Sig
+end
+
+module Psych::JSON
+end
+
+module Psych::JSON::RubyEvents
+  def visit_DateTime(o); end
+
+  def visit_String(o); end
+
+  def visit_Symbol(o); end
+
+  def visit_Time(o); end
+end
+
+module Psych::JSON::RubyEvents
+  extend ::T::Sig
+end
+
+class Psych::JSON::Stream
+  include ::Psych::Streaming
+end
+
+class Psych::JSON::Stream::Emitter
+  include ::Psych::JSON::YAMLEvents
+end
+
+class Psych::JSON::Stream::Emitter
+end
+
+class Psych::JSON::Stream
+  extend ::Psych::Streaming::ClassMethods
+end
+
+class Psych::JSON::TreeBuilder
+  include ::Psych::JSON::YAMLEvents
+end
+
+class Psych::JSON::TreeBuilder
+end
+
+module Psych::JSON::YAMLEvents
+  def end_document(implicit_end=T.unsafe(nil)); end
+
+  def scalar(value, anchor, tag, plain, quoted, style); end
+
+  def start_document(version, tag_directives, implicit); end
+
+  def start_mapping(anchor, tag, implicit, style); end
+
+  def start_sequence(anchor, tag, implicit, style); end
+end
+
+module Psych::JSON::YAMLEvents
+  extend ::T::Sig
+end
+
+module Psych::JSON
+  extend ::T::Sig
+end
+
+module Psych::Nodes
+end
+
+class Psych::Nodes::Alias
+  def anchor(); end
+
+  def anchor=(anchor); end
+
+  def initialize(anchor); end
+end
+
+class Psych::Nodes::Alias
+end
+
+class Psych::Nodes::Document
+  def implicit(); end
+
+  def implicit=(implicit); end
+
+  def implicit_end(); end
+
+  def implicit_end=(implicit_end); end
+
+  def initialize(version=T.unsafe(nil), tag_directives=T.unsafe(nil), implicit=T.unsafe(nil)); end
+
+  def root(); end
+
+  def tag_directives(); end
+
+  def tag_directives=(tag_directives); end
+
+  def version(); end
+
+  def version=(version); end
+end
+
+class Psych::Nodes::Document
+end
+
+class Psych::Nodes::Mapping
+  def anchor(); end
+
+  def anchor=(anchor); end
+
+  def implicit(); end
+
+  def implicit=(implicit); end
+
+  def initialize(anchor=T.unsafe(nil), tag=T.unsafe(nil), implicit=T.unsafe(nil), style=T.unsafe(nil)); end
+
+  def style(); end
+
+  def style=(style); end
+
+  def tag=(tag); end
+  ANY = ::T.let(nil, ::T.untyped)
+  BLOCK = ::T.let(nil, ::T.untyped)
+  FLOW = ::T.let(nil, ::T.untyped)
+end
+
+class Psych::Nodes::Mapping
+end
+
+class Psych::Nodes::Node
+  include ::Enumerable
+  def alias?(); end
+
+  def children(); end
+
+  def document?(); end
+
+  def each(&block); end
+
+  def end_column(); end
+
+  def end_column=(end_column); end
+
+  def end_line(); end
+
+  def end_line=(end_line); end
+
+  def mapping?(); end
+
+  def scalar?(); end
+
+  def sequence?(); end
+
+  def start_column(); end
+
+  def start_column=(start_column); end
+
+  def start_line(); end
+
+  def start_line=(start_line); end
+
+  def stream?(); end
+
+  def tag(); end
+
+  def to_ruby(); end
+
+  def to_yaml(io=T.unsafe(nil), options=T.unsafe(nil)); end
+
+  def transform(); end
+
+  def yaml(io=T.unsafe(nil), options=T.unsafe(nil)); end
+end
+
+class Psych::Nodes::Node
+end
+
+class Psych::Nodes::Scalar
+  def anchor(); end
+
+  def anchor=(anchor); end
+
+  def initialize(value, anchor=T.unsafe(nil), tag=T.unsafe(nil), plain=T.unsafe(nil), quoted=T.unsafe(nil), style=T.unsafe(nil)); end
+
+  def plain(); end
+
+  def plain=(plain); end
+
+  def quoted(); end
+
+  def quoted=(quoted); end
+
+  def style(); end
+
+  def style=(style); end
+
+  def tag=(tag); end
+
+  def value(); end
+
+  def value=(value); end
+  ANY = ::T.let(nil, ::T.untyped)
+  DOUBLE_QUOTED = ::T.let(nil, ::T.untyped)
+  FOLDED = ::T.let(nil, ::T.untyped)
+  LITERAL = ::T.let(nil, ::T.untyped)
+  PLAIN = ::T.let(nil, ::T.untyped)
+  SINGLE_QUOTED = ::T.let(nil, ::T.untyped)
+end
+
+class Psych::Nodes::Scalar
+end
+
+class Psych::Nodes::Sequence
+  def anchor(); end
+
+  def anchor=(anchor); end
+
+  def implicit(); end
+
+  def implicit=(implicit); end
+
+  def initialize(anchor=T.unsafe(nil), tag=T.unsafe(nil), implicit=T.unsafe(nil), style=T.unsafe(nil)); end
+
+  def style(); end
+
+  def style=(style); end
+
+  def tag=(tag); end
+  ANY = ::T.let(nil, ::T.untyped)
+  BLOCK = ::T.let(nil, ::T.untyped)
+  FLOW = ::T.let(nil, ::T.untyped)
+end
+
+class Psych::Nodes::Sequence
+end
+
+class Psych::Nodes::Stream
+  def encoding(); end
+
+  def encoding=(encoding); end
+
+  def initialize(encoding=T.unsafe(nil)); end
+  ANY = ::T.let(nil, ::T.untyped)
+  UTF16BE = ::T.let(nil, ::T.untyped)
+  UTF16LE = ::T.let(nil, ::T.untyped)
+  UTF8 = ::T.let(nil, ::T.untyped)
+end
+
+class Psych::Nodes::Stream
+end
+
+module Psych::Nodes
+  extend ::T::Sig
+end
+
+class Psych::Omap
+end
+
+class Psych::Omap
+end
+
+class Psych::Parser
+  def external_encoding=(external_encoding); end
+
+  def handler(); end
+
+  def handler=(handler); end
+
+  def initialize(handler=T.unsafe(nil)); end
+
+  def mark(); end
+
+  def parse(*_); end
+  ANY = ::T.let(nil, ::T.untyped)
+  UTF16BE = ::T.let(nil, ::T.untyped)
+  UTF16LE = ::T.let(nil, ::T.untyped)
+  UTF8 = ::T.let(nil, ::T.untyped)
+end
+
+class Psych::Parser::Mark
+end
+
+class Psych::Parser::Mark
+end
+
+class Psych::Parser
+end
+
+class Psych::ScalarScanner
+  def class_loader(); end
+
+  def initialize(class_loader); end
+
+  def parse_int(string); end
+
+  def parse_time(string); end
+
+  def tokenize(string); end
+  FLOAT = ::T.let(nil, ::T.untyped)
+  INTEGER = ::T.let(nil, ::T.untyped)
+  TIME = ::T.let(nil, ::T.untyped)
+end
+
+class Psych::ScalarScanner
+end
+
+class Psych::Set
+end
+
+class Psych::Set
+end
+
+class Psych::Stream
+  include ::Psych::Streaming
+end
+
+class Psych::Stream::Emitter
+  def end_document(implicit_end=T.unsafe(nil)); end
+end
+
+class Psych::Stream::Emitter
+end
+
+class Psych::Stream
+  extend ::Psych::Streaming::ClassMethods
+end
+
+module Psych::Streaming
+  def start(encoding=T.unsafe(nil)); end
+end
+
+module Psych::Streaming::ClassMethods
+  def new(io); end
+end
+
+module Psych::Streaming::ClassMethods
+  extend ::T::Sig
+end
+
+module Psych::Streaming
+  extend ::T::Sig
+end
+
+class Psych::SyntaxError
+  def column(); end
+
+  def context(); end
+
+  def file(); end
+
+  def initialize(file, line, col, offset, problem, context); end
+
+  def line(); end
+
+  def offset(); end
+
+  def problem(); end
+end
+
+class Psych::SyntaxError
+end
+
+class Psych::TreeBuilder
+  def end_document(implicit_end=T.unsafe(nil)); end
+
+  def root(); end
+end
+
+class Psych::TreeBuilder
+end
+
+module Psych::Visitors
+end
+
+class Psych::Visitors::DepthFirst
+  def initialize(block); end
+end
+
+class Psych::Visitors::DepthFirst
+end
+
+class Psych::Visitors::Emitter
+  def initialize(io, options=T.unsafe(nil)); end
+
+  def visit_Psych_Nodes_Alias(o); end
+
+  def visit_Psych_Nodes_Document(o); end
+
+  def visit_Psych_Nodes_Mapping(o); end
+
+  def visit_Psych_Nodes_Scalar(o); end
+
+  def visit_Psych_Nodes_Sequence(o); end
+
+  def visit_Psych_Nodes_Stream(o); end
+end
+
+class Psych::Visitors::Emitter
+end
+
+class Psych::Visitors::JSONTree
+  include ::Psych::JSON::RubyEvents
+end
+
+class Psych::Visitors::JSONTree
+  def self.create(options=T.unsafe(nil)); end
+end
+
+class Psych::Visitors::NoAliasRuby
+end
+
+class Psych::Visitors::NoAliasRuby
+end
+
+class Psych::Visitors::ToRuby
+  def class_loader(); end
+
+  def initialize(ss, class_loader); end
+
+  def visit_Psych_Nodes_Alias(o); end
+
+  def visit_Psych_Nodes_Document(o); end
+
+  def visit_Psych_Nodes_Mapping(o); end
+
+  def visit_Psych_Nodes_Scalar(o); end
+
+  def visit_Psych_Nodes_Sequence(o); end
+
+  def visit_Psych_Nodes_Stream(o); end
+  SHOVEL = ::T.let(nil, ::T.untyped)
+end
+
+class Psych::Visitors::ToRuby
+  def self.create(); end
+end
+
+class Psych::Visitors::Visitor
+  def accept(target); end
+  DISPATCH = ::T.let(nil, ::T.untyped)
+end
+
+class Psych::Visitors::Visitor
+end
+
+class Psych::Visitors::YAMLTree
+  def <<(object); end
+
+  def finish(); end
+
+  def finished(); end
+
+  def finished?(); end
+
+  def initialize(emitter, ss, options); end
+
+  def push(object); end
+
+  def start(encoding=T.unsafe(nil)); end
+
+  def started(); end
+
+  def started?(); end
+
+  def tree(); end
+
+  def visit_Array(o); end
+
+  def visit_BasicObject(o); end
+
+  def visit_BigDecimal(o); end
+
+  def visit_Class(o); end
+
+  def visit_Complex(o); end
+
+  def visit_Date(o); end
+
+  def visit_DateTime(o); end
+
+  def visit_Delegator(o); end
+
+  def visit_Encoding(o); end
+
+  def visit_Enumerator(o); end
+
+  def visit_Exception(o); end
+
+  def visit_FalseClass(o); end
+
+  def visit_Float(o); end
+
+  def visit_Hash(o); end
+
+  def visit_Integer(o); end
+
+  def visit_Module(o); end
+
+  def visit_NameError(o); end
+
+  def visit_NilClass(o); end
+
+  def visit_Object(o); end
+
+  def visit_Psych_Omap(o); end
+
+  def visit_Psych_Set(o); end
+
+  def visit_Range(o); end
+
+  def visit_Rational(o); end
+
+  def visit_Regexp(o); end
+
+  def visit_String(o); end
+
+  def visit_Struct(o); end
+
+  def visit_Symbol(o); end
+
+  def visit_Time(o); end
+
+  def visit_TrueClass(o); end
+end
+
+class Psych::Visitors::YAMLTree
+  def self.create(options=T.unsafe(nil), emitter=T.unsafe(nil)); end
+end
+
+module Psych::Visitors
+  extend ::T::Sig
+end
+
+module Psych
+  extend ::T::Sig
+  def self.add_builtin_type(type_tag, &block); end
+
+  def self.add_domain_type(domain, type_tag, &block); end
+
+  def self.add_tag(tag, klass); end
+
+  def self.domain_types(); end
+
+  def self.domain_types=(domain_types); end
+
+  def self.dump(o, io=T.unsafe(nil), options=T.unsafe(nil)); end
+
+  def self.dump_stream(*objects); end
+
+  def self.dump_tags(); end
+
+  def self.dump_tags=(dump_tags); end
+
+  def self.libyaml_version(); end
+
+  def self.load(yaml, legacy_filename=T.unsafe(nil), filename: T.unsafe(nil), fallback: T.unsafe(nil), symbolize_names: T.unsafe(nil)); end
+
+  def self.load_file(filename, fallback: T.unsafe(nil)); end
+
+  def self.load_stream(yaml, legacy_filename=T.unsafe(nil), filename: T.unsafe(nil), fallback: T.unsafe(nil)); end
+
+  def self.load_tags(); end
+
+  def self.load_tags=(load_tags); end
+
+  def self.parse(yaml, legacy_filename=T.unsafe(nil), filename: T.unsafe(nil), fallback: T.unsafe(nil)); end
+
+  def self.parse_file(filename, fallback: T.unsafe(nil)); end
+
+  def self.parse_stream(yaml, legacy_filename=T.unsafe(nil), filename: T.unsafe(nil), &block); end
+
+  def self.parser(); end
+
+  def self.remove_type(type_tag); end
+
+  def self.safe_load(yaml, legacy_permitted_classes=T.unsafe(nil), legacy_permitted_symbols=T.unsafe(nil), legacy_aliases=T.unsafe(nil), legacy_filename=T.unsafe(nil), permitted_classes: T.unsafe(nil), permitted_symbols: T.unsafe(nil), aliases: T.unsafe(nil), filename: T.unsafe(nil), fallback: T.unsafe(nil), symbolize_names: T.unsafe(nil)); end
+
+  def self.to_json(object); end
+end
+
 Queue = Thread::Queue
-
-class RDoc::TestCase
-  def assert_directory(path); end
-
-  def assert_file(path); end
-
-  def blank_line(); end
-
-  def block(*contents); end
-
-  def comment(text, top_level=T.unsafe(nil)); end
-
-  def doc(*contents); end
-
-  def hard_break(); end
-
-  def head(level, text); end
-
-  def item(label=T.unsafe(nil), *parts); end
-
-  def list(type=T.unsafe(nil), *items); end
-
-  def para(*a); end
-
-  def raw(*contents); end
-
-  def refute_file(path); end
-
-  def rule(weight); end
-
-  def temp_dir(); end
-
-  def verb(*parts); end
-
-  def verbose_capture_io(); end
-end
-
-class RDoc::TestCase
-end
 
 module RDoc::Text
   def expand_tabs(text); end
@@ -8356,6 +8921,11 @@ end
 RSpec::Core::Example::AllExceptionsExcludingDangerousOnesOnRubiesThatAllowIt = RSpec::Support::AllExceptionsExceptOnesWeMustNotRescue
 
 class RSpec::Core::ExampleGroup
+  include ::RSpec::Core::MockingAdapters::RSpec
+  include ::RSpec::Mocks::ExampleMethods
+  include ::RSpec::Mocks::ArgumentMatchers
+  include ::RSpec::Mocks::ExampleMethods::ExpectHost
+  include ::RSpec::Matchers
   INSTANCE_VARIABLE_TO_IGNORE = ::T.let(nil, ::T.untyped)
 end
 
@@ -8626,6 +9196,14 @@ module RSpec::Core::MetadataFilter
   extend ::T::Sig
 end
 
+module RSpec::Core::MockingAdapters::RSpec
+  extend ::T::Sig
+end
+
+module RSpec::Core::MockingAdapters
+  extend ::T::Sig
+end
+
 module RSpec::Core::MultipleExceptionError::InterfaceTag
   extend ::T::Sig
 end
@@ -8778,6 +9356,1321 @@ module RSpec::ExampleGroups
   extend ::T::Sig
 end
 
+class RSpec::Expectations::BlockSnippetExtractor
+  def body_content_lines(); end
+
+  def initialize(proc, method_name); end
+
+  def method_name(); end
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::AmbiguousTargetError
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::AmbiguousTargetError
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::BlockLocator
+  def beginning_line_number(); end
+
+  def beginning_line_number=(_); end
+
+  def body_content_locations(); end
+
+  def method_call_location(); end
+
+  def method_name(); end
+
+  def method_name=(_); end
+
+  def source(); end
+
+  def source=(_); end
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::BlockLocator
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::BlockTokenExtractor
+  def beginning_line_number(); end
+
+  def beginning_line_number=(_); end
+
+  def body_tokens(); end
+
+  def method_name(); end
+
+  def method_name=(_); end
+
+  def source(); end
+
+  def source=(_); end
+
+  def state(); end
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::BlockTokenExtractor
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::Error
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::Error
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::TargetNotFoundError
+end
+
+class RSpec::Expectations::BlockSnippetExtractor::TargetNotFoundError
+end
+
+class RSpec::Expectations::BlockSnippetExtractor
+  def self.try_extracting_single_line_body_of(proc, method_name); end
+end
+
+class RSpec::Expectations::Configuration
+  FALSE_POSITIVE_BEHAVIOURS = ::T.let(nil, ::T.untyped)
+end
+
+module RSpec::Expectations::Configuration::NullBacktraceFormatter
+  extend ::T::Sig
+end
+
+module RSpec::Expectations::ExpectationHelper
+  extend ::T::Sig
+end
+
+module RSpec::Expectations::ExpectationTarget::InstanceMethods
+  extend ::T::Sig
+end
+
+module RSpec::Expectations::ExpectationTarget::UndefinedValue
+  extend ::T::Sig
+end
+
+class RSpec::Expectations::FailureAggregator
+  def aggregate(); end
+
+  def block_label(); end
+
+  def call(failure, options); end
+
+  def failures(); end
+
+  def initialize(block_label, metadata); end
+
+  def metadata(); end
+
+  def other_errors(); end
+end
+
+class RSpec::Expectations::FailureAggregator
+end
+
+RSpec::Expectations::LegacyMacherAdapter = RSpec::Expectations::LegacyMatcherAdapter
+
+class RSpec::Expectations::MultipleExpectationsNotMetError
+  include ::RSpec::Core::MultipleExceptionError::InterfaceTag
+  def aggregation_block_label(); end
+
+  def aggregation_metadata(); end
+
+  def all_exceptions(); end
+
+  def exception_count_description(); end
+
+  def failures(); end
+
+  def initialize(failure_aggregator); end
+
+  def other_errors(); end
+
+  def summary(); end
+end
+
+module RSpec::Expectations::Syntax
+  extend ::T::Sig
+end
+
+module RSpec::Expectations::Version
+  STRING = ::T.let(nil, ::T.untyped)
+end
+
+module RSpec::Expectations::Version
+  extend ::T::Sig
+end
+
+module RSpec::Expectations
+  extend ::T::Sig
+end
+
+module RSpec::Matchers
+  def log(*expected, &block_arg); end
+
+  def not_log(*expected, &block_arg); end
+  BE_PREDICATE_REGEX = ::T.let(nil, ::T.untyped)
+  DYNAMIC_MATCHER_REGEX = ::T.let(nil, ::T.untyped)
+  HAS_REGEX = ::T.let(nil, ::T.untyped)
+end
+
+RSpec::Matchers::AliasedNegatedMatcher::DefaultFailureMessages = RSpec::Matchers::BuiltIn::BaseMatcher::DefaultFailureMessages
+
+class RSpec::Matchers::BuiltIn::All
+  def does_not_match?(_actual); end
+
+  def failed_objects(); end
+
+  def initialize(matcher); end
+
+  def matcher(); end
+end
+
+class RSpec::Matchers::BuiltIn::All
+end
+
+class RSpec::Matchers::BuiltIn::BaseMatcher
+  UNDEFINED = ::T.let(nil, ::T.untyped)
+end
+
+module RSpec::Matchers::BuiltIn::BaseMatcher::DefaultFailureMessages
+  extend ::T::Sig
+end
+
+module RSpec::Matchers::BuiltIn::BaseMatcher::HashFormatting
+  extend ::T::Sig
+end
+
+class RSpec::Matchers::BuiltIn::Be
+  include ::RSpec::Matchers::BuiltIn::BeHelpers
+  def <(operand); end
+
+  def <=(operand); end
+
+  def ==(operand); end
+
+  def ===(operand); end
+
+  def =~(operand); end
+
+  def >(operand); end
+
+  def >=(operand); end
+
+  def initialize(*args); end
+end
+
+class RSpec::Matchers::BuiltIn::Be
+end
+
+class RSpec::Matchers::BuiltIn::BeAKindOf
+end
+
+class RSpec::Matchers::BuiltIn::BeAKindOf
+end
+
+class RSpec::Matchers::BuiltIn::BeAnInstanceOf
+end
+
+class RSpec::Matchers::BuiltIn::BeAnInstanceOf
+end
+
+class RSpec::Matchers::BuiltIn::BeBetween
+  def exclusive(); end
+
+  def inclusive(); end
+
+  def initialize(min, max); end
+end
+
+class RSpec::Matchers::BuiltIn::BeBetween
+end
+
+class RSpec::Matchers::BuiltIn::BeComparedTo
+  include ::RSpec::Matchers::BuiltIn::BeHelpers
+  def initialize(operand, operator); end
+end
+
+class RSpec::Matchers::BuiltIn::BeComparedTo
+end
+
+class RSpec::Matchers::BuiltIn::BeFalsey
+end
+
+class RSpec::Matchers::BuiltIn::BeFalsey
+end
+
+module RSpec::Matchers::BuiltIn::BeHelpers
+end
+
+module RSpec::Matchers::BuiltIn::BeHelpers
+  extend ::T::Sig
+end
+
+class RSpec::Matchers::BuiltIn::BeNil
+end
+
+class RSpec::Matchers::BuiltIn::BeNil
+end
+
+class RSpec::Matchers::BuiltIn::BePredicate
+  include ::RSpec::Matchers::BuiltIn::BeHelpers
+  def does_not_match?(actual, &block); end
+
+  def initialize(*args, &block); end
+
+  def matches?(actual, &block); end
+end
+
+class RSpec::Matchers::BuiltIn::BePredicate
+end
+
+class RSpec::Matchers::BuiltIn::BeTruthy
+end
+
+class RSpec::Matchers::BuiltIn::BeTruthy
+end
+
+class RSpec::Matchers::BuiltIn::BeWithin
+  def initialize(delta); end
+
+  def of(expected); end
+
+  def percent_of(expected); end
+end
+
+class RSpec::Matchers::BuiltIn::BeWithin
+end
+
+class RSpec::Matchers::BuiltIn::Change
+  def by(expected_delta); end
+
+  def by_at_least(minimum); end
+
+  def by_at_most(maximum); end
+
+  def does_not_match?(event_proc); end
+
+  def from(value); end
+
+  def initialize(receiver=T.unsafe(nil), message=T.unsafe(nil), &block); end
+
+  def matches?(event_proc); end
+
+  def to(value); end
+end
+
+class RSpec::Matchers::BuiltIn::Change
+end
+
+class RSpec::Matchers::BuiltIn::Compound
+  def diffable_matcher_list(); end
+
+  def does_not_match?(_actual); end
+
+  def evaluator(); end
+
+  def initialize(matcher_1, matcher_2); end
+
+  def matcher_1(); end
+
+  def matcher_2(); end
+end
+
+class RSpec::Matchers::BuiltIn::Compound::And
+end
+
+class RSpec::Matchers::BuiltIn::Compound::And
+end
+
+class RSpec::Matchers::BuiltIn::Compound::NestedEvaluator
+  def initialize(actual, matcher_1, matcher_2); end
+
+  def matcher_matches?(matcher); end
+end
+
+class RSpec::Matchers::BuiltIn::Compound::NestedEvaluator
+  def self.matcher_expects_call_stack_jump?(matcher); end
+end
+
+class RSpec::Matchers::BuiltIn::Compound::Or
+end
+
+class RSpec::Matchers::BuiltIn::Compound::Or
+end
+
+class RSpec::Matchers::BuiltIn::Compound::SequentialEvaluator
+  def initialize(actual, *_); end
+
+  def matcher_matches?(matcher); end
+end
+
+class RSpec::Matchers::BuiltIn::Compound::SequentialEvaluator
+end
+
+class RSpec::Matchers::BuiltIn::Compound
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly::PairingsMaximizer
+  def actual_to_expected_matched_indexes(); end
+
+  def expected_to_actual_matched_indexes(); end
+
+  def find_best_solution(); end
+
+  def initialize(expected_to_actual_matched_indexes, actual_to_expected_matched_indexes); end
+
+  def solution(); end
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly::PairingsMaximizer::NullSolution
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly::PairingsMaximizer::NullSolution
+  def self.worse_than?(_other); end
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly::PairingsMaximizer::Solution
+  def +(derived_candidate_solution); end
+
+  def candidate?(); end
+
+  def ideal?(); end
+
+  def indeterminate_actual_indexes(); end
+
+  def indeterminate_actual_indexes=(_); end
+
+  def indeterminate_expected_indexes(); end
+
+  def indeterminate_expected_indexes=(_); end
+
+  def unmatched_actual_indexes(); end
+
+  def unmatched_actual_indexes=(_); end
+
+  def unmatched_expected_indexes(); end
+
+  def unmatched_expected_indexes=(_); end
+
+  def unmatched_item_count(); end
+
+  def worse_than?(other); end
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly::PairingsMaximizer::Solution
+  def self.[](*_); end
+
+  def self.members(); end
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly::PairingsMaximizer
+end
+
+class RSpec::Matchers::BuiltIn::ContainExactly
+end
+
+class RSpec::Matchers::BuiltIn::Cover
+  def does_not_match?(range); end
+
+  def initialize(*expected); end
+
+  def matches?(range); end
+end
+
+class RSpec::Matchers::BuiltIn::Cover
+end
+
+class RSpec::Matchers::BuiltIn::EndWith
+end
+
+class RSpec::Matchers::BuiltIn::EndWith
+end
+
+class RSpec::Matchers::BuiltIn::Eq
+end
+
+class RSpec::Matchers::BuiltIn::Eq
+end
+
+class RSpec::Matchers::BuiltIn::Eql
+end
+
+class RSpec::Matchers::BuiltIn::Eql
+end
+
+class RSpec::Matchers::BuiltIn::Equal
+  LITERAL_SINGLETONS = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Matchers::BuiltIn::Equal
+end
+
+class RSpec::Matchers::BuiltIn::Exist
+  def does_not_match?(actual); end
+
+  def initialize(*expected); end
+end
+
+class RSpec::Matchers::BuiltIn::Exist::ExistenceTest
+  def actual_exists?(); end
+
+  def valid_test?(); end
+
+  def validity_message(); end
+end
+
+class RSpec::Matchers::BuiltIn::Exist::ExistenceTest
+end
+
+class RSpec::Matchers::BuiltIn::Exist
+end
+
+class RSpec::Matchers::BuiltIn::Has
+  def does_not_match?(actual, &block); end
+
+  def initialize(method_name, *args, &block); end
+
+  def matches?(actual, &block); end
+end
+
+class RSpec::Matchers::BuiltIn::Has
+end
+
+class RSpec::Matchers::BuiltIn::HaveAttributes
+  def does_not_match?(actual); end
+
+  def initialize(expected); end
+
+  def respond_to_failed(); end
+end
+
+class RSpec::Matchers::BuiltIn::HaveAttributes
+end
+
+class RSpec::Matchers::BuiltIn::Include
+  def does_not_match?(actual); end
+
+  def expecteds(); end
+
+  def initialize(*expecteds); end
+end
+
+class RSpec::Matchers::BuiltIn::Include
+end
+
+class RSpec::Matchers::BuiltIn::Match
+  def initialize(expected); end
+
+  def with_captures(*captures); end
+end
+
+class RSpec::Matchers::BuiltIn::Match
+end
+
+class RSpec::Matchers::BuiltIn::NegativeOperatorMatcher
+  def __delegate_operator(actual, operator, expected); end
+end
+
+class RSpec::Matchers::BuiltIn::NegativeOperatorMatcher
+end
+
+class RSpec::Matchers::BuiltIn::OperatorMatcher
+  def !=(_expected); end
+
+  def !~(_expected); end
+
+  def <(expected); end
+
+  def <=(expected); end
+
+  def ==(expected); end
+
+  def ===(expected); end
+
+  def =~(expected); end
+
+  def >(expected); end
+
+  def >=(expected); end
+
+  def description(); end
+
+  def fail_with_message(message); end
+
+  def initialize(actual); end
+end
+
+class RSpec::Matchers::BuiltIn::OperatorMatcher
+  def self.get(klass, operator); end
+
+  def self.register(klass, operator, matcher); end
+
+  def self.registry(); end
+
+  def self.unregister(klass, operator); end
+
+  def self.use_custom_matcher_or_delegate(operator); end
+end
+
+class RSpec::Matchers::BuiltIn::Output
+  def does_not_match?(block); end
+
+  def initialize(expected); end
+
+  def matches?(block); end
+
+  def to_stderr(); end
+
+  def to_stderr_from_any_process(); end
+
+  def to_stdout(); end
+
+  def to_stdout_from_any_process(); end
+end
+
+class RSpec::Matchers::BuiltIn::Output
+end
+
+class RSpec::Matchers::BuiltIn::PositiveOperatorMatcher
+  def __delegate_operator(actual, operator, expected); end
+end
+
+class RSpec::Matchers::BuiltIn::PositiveOperatorMatcher
+end
+
+class RSpec::Matchers::BuiltIn::RaiseError
+  include ::RSpec::Matchers::Composable
+  def description(); end
+
+  def does_not_match?(given_proc); end
+
+  def expects_call_stack_jump?(); end
+
+  def failure_message(); end
+
+  def failure_message_when_negated(); end
+
+  def initialize(expected_error_or_message=T.unsafe(nil), expected_message=T.unsafe(nil), &block); end
+
+  def matches?(given_proc, negative_expectation=T.unsafe(nil), &block); end
+
+  def supports_block_expectations?(); end
+
+  def with_message(expected_message); end
+end
+
+class RSpec::Matchers::BuiltIn::RaiseError
+end
+
+class RSpec::Matchers::BuiltIn::RespondTo
+  def and_any_keywords(); end
+
+  def and_keywords(*keywords); end
+
+  def and_unlimited_arguments(); end
+
+  def argument(); end
+
+  def arguments(); end
+
+  def does_not_match?(actual); end
+
+  def initialize(*names); end
+
+  def with(n); end
+
+  def with_any_keywords(); end
+
+  def with_keywords(*keywords); end
+
+  def with_unlimited_arguments(); end
+end
+
+class RSpec::Matchers::BuiltIn::RespondTo
+end
+
+class RSpec::Matchers::BuiltIn::Satisfy
+  def initialize(description=T.unsafe(nil), &block); end
+
+  def matches?(actual, &block); end
+end
+
+class RSpec::Matchers::BuiltIn::Satisfy
+end
+
+class RSpec::Matchers::BuiltIn::StartOrEndWith
+  def initialize(*expected); end
+end
+
+class RSpec::Matchers::BuiltIn::StartOrEndWith
+end
+
+class RSpec::Matchers::BuiltIn::StartWith
+end
+
+class RSpec::Matchers::BuiltIn::StartWith
+end
+
+class RSpec::Matchers::BuiltIn::ThrowSymbol
+  include ::RSpec::Matchers::Composable
+  def description(); end
+
+  def does_not_match?(given_proc); end
+
+  def expects_call_stack_jump?(); end
+
+  def failure_message(); end
+
+  def failure_message_when_negated(); end
+
+  def initialize(expected_symbol=T.unsafe(nil), expected_arg=T.unsafe(nil)); end
+
+  def matches?(given_proc); end
+
+  def supports_block_expectations?(); end
+end
+
+class RSpec::Matchers::BuiltIn::ThrowSymbol
+end
+
+class RSpec::Matchers::BuiltIn::YieldControl
+  def at_least(number); end
+
+  def at_most(number); end
+
+  def does_not_match?(block); end
+
+  def exactly(number); end
+
+  def initialize(); end
+
+  def matches?(block); end
+
+  def once(); end
+
+  def thrice(); end
+
+  def times(); end
+
+  def twice(); end
+end
+
+class RSpec::Matchers::BuiltIn::YieldControl
+end
+
+class RSpec::Matchers::BuiltIn::YieldSuccessiveArgs
+  def does_not_match?(block); end
+
+  def initialize(*args); end
+
+  def matches?(block); end
+end
+
+class RSpec::Matchers::BuiltIn::YieldSuccessiveArgs
+end
+
+class RSpec::Matchers::BuiltIn::YieldWithArgs
+  def does_not_match?(block); end
+
+  def initialize(*args); end
+
+  def matches?(block); end
+end
+
+class RSpec::Matchers::BuiltIn::YieldWithArgs
+end
+
+class RSpec::Matchers::BuiltIn::YieldWithNoArgs
+  def does_not_match?(block); end
+
+  def matches?(block); end
+end
+
+class RSpec::Matchers::BuiltIn::YieldWithNoArgs
+end
+
+module RSpec::Matchers::BuiltIn
+  extend ::T::Sig
+end
+
+module RSpec::Matchers::Composable
+  extend ::T::Sig
+end
+
+module RSpec::Matchers::DSL::DefaultImplementations
+  extend ::T::Sig
+end
+
+module RSpec::Matchers::DSL::Macros
+  RAISE_NOTIFIER = ::T.let(nil, ::T.untyped)
+end
+
+module RSpec::Matchers::DSL::Macros::Deprecated
+  extend ::T::Sig
+end
+
+module RSpec::Matchers::DSL::Macros
+  extend ::T::Sig
+end
+
+module RSpec::Matchers::DSL
+  extend ::T::Sig
+end
+
+module RSpec::Matchers::EnglishPhrasing
+  extend ::T::Sig
+end
+
+class RSpec::Matchers::ExpectedsForMultipleDiffs
+  DEFAULT_DIFF_LABEL = ::T.let(nil, ::T.untyped)
+  DESCRIPTION_MAX_LENGTH = ::T.let(nil, ::T.untyped)
+end
+
+module RSpec::Matchers
+  extend ::T::Sig
+end
+
+module RSpec::Mocks
+  DEFAULT_CALLBACK_INVOCATION_STRATEGY = ::T.let(nil, ::T.untyped)
+  IGNORED_BACKTRACE_LINE = ::T.let(nil, ::T.untyped)
+end
+
+module RSpec::Mocks::AnyInstance
+end
+
+class RSpec::Mocks::AnyInstance::Chain
+  include ::RSpec::Mocks::AnyInstance::Chain::Customizations
+  def constrained_to_any_of?(*constraints); end
+
+  def expectation_fulfilled!(); end
+
+  def initialize(recorder, *args, &block); end
+
+  def matches_args?(*args); end
+
+  def never(); end
+
+  def playback!(instance); end
+end
+
+module RSpec::Mocks::AnyInstance::Chain::Customizations
+  def and_call_original(*args, &block); end
+
+  def and_raise(*args, &block); end
+
+  def and_return(*args, &block); end
+
+  def and_throw(*args, &block); end
+
+  def and_wrap_original(*args, &block); end
+
+  def and_yield(*args, &block); end
+
+  def at_least(*args, &block); end
+
+  def at_most(*args, &block); end
+
+  def exactly(*args, &block); end
+
+  def never(*args, &block); end
+
+  def once(*args, &block); end
+
+  def thrice(*args, &block); end
+
+  def times(*args, &block); end
+
+  def twice(*args, &block); end
+
+  def with(*args, &block); end
+end
+
+module RSpec::Mocks::AnyInstance::Chain::Customizations
+  extend ::T::Sig
+  def self.record(method_name); end
+end
+
+class RSpec::Mocks::AnyInstance::Chain
+end
+
+class RSpec::Mocks::AnyInstance::ErrorGenerator
+  def raise_does_not_implement_error(klass, method_name); end
+
+  def raise_message_already_received_by_other_instance_error(method_name, object_inspect, invoked_instance); end
+
+  def raise_not_supported_with_prepend_error(method_name, problem_mod); end
+
+  def raise_second_instance_received_message_error(unfulfilled_expectations); end
+end
+
+class RSpec::Mocks::AnyInstance::ErrorGenerator
+end
+
+class RSpec::Mocks::AnyInstance::ExpectChainChain
+  def initialize(*args); end
+end
+
+class RSpec::Mocks::AnyInstance::ExpectChainChain
+end
+
+class RSpec::Mocks::AnyInstance::ExpectationChain
+  def expectation_fulfilled?(); end
+
+  def initialize(*args, &block); end
+end
+
+class RSpec::Mocks::AnyInstance::ExpectationChain
+end
+
+class RSpec::Mocks::AnyInstance::FluentInterfaceProxy
+  def initialize(targets); end
+
+  def method_missing(*args, &block); end
+end
+
+class RSpec::Mocks::AnyInstance::FluentInterfaceProxy
+end
+
+class RSpec::Mocks::AnyInstance::MessageChains
+  def [](method_name); end
+
+  def add(method_name, chain); end
+
+  def all_expectations_fulfilled?(); end
+
+  def each_unfulfilled_expectation_matching(method_name, *args); end
+
+  def has_expectation?(method_name); end
+
+  def playback!(instance, method_name); end
+
+  def received_expected_message!(method_name); end
+
+  def remove_stub_chains_for!(method_name); end
+
+  def unfulfilled_expectations(); end
+end
+
+class RSpec::Mocks::AnyInstance::MessageChains
+end
+
+class RSpec::Mocks::AnyInstance::PositiveExpectationChain
+  ExpectationInvocationOrder = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Mocks::AnyInstance::PositiveExpectationChain
+end
+
+class RSpec::Mocks::AnyInstance::Proxy
+  def expect_chain(*chain, &block); end
+
+  def initialize(recorder, target_proxies); end
+
+  def klass(); end
+
+  def should_not_receive(method_name, &block); end
+
+  def should_receive(method_name, &block); end
+
+  def stub(method_name_or_method_map, &block); end
+
+  def stub_chain(*chain, &block); end
+
+  def unstub(method_name); end
+end
+
+class RSpec::Mocks::AnyInstance::Proxy
+end
+
+class RSpec::Mocks::AnyInstance::Recorder
+  def already_observing?(method_name); end
+
+  def build_alias_method_name(method_name); end
+
+  def expect_chain(*method_names_and_optional_return_values, &block); end
+
+  def initialize(klass); end
+
+  def instance_that_received(method_name); end
+
+  def klass(); end
+
+  def message_chains(); end
+
+  def notify_received_message(_object, message, args, _blk); end
+
+  def playback!(instance, method_name); end
+
+  def should_not_receive(method_name, &block); end
+
+  def should_receive(method_name, &block); end
+
+  def stop_all_observation!(); end
+
+  def stop_observing!(method_name); end
+
+  def stub(method_name, &block); end
+
+  def stub_chain(*method_names_and_optional_return_values, &block); end
+
+  def stubs(); end
+
+  def unstub(method_name); end
+
+  def verify(); end
+end
+
+class RSpec::Mocks::AnyInstance::Recorder
+end
+
+class RSpec::Mocks::AnyInstance::StubChain
+  def expectation_fulfilled?(); end
+  EmptyInvocationOrder = ::T.let(nil, ::T.untyped)
+  InvocationOrder = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Mocks::AnyInstance::StubChain
+end
+
+class RSpec::Mocks::AnyInstance::StubChainChain
+  def initialize(*args); end
+end
+
+class RSpec::Mocks::AnyInstance::StubChainChain
+end
+
+module RSpec::Mocks::AnyInstance
+  extend ::T::Sig
+  def self.error_generator(); end
+end
+
+class RSpec::Mocks::ArgumentListMatcher
+  MATCH_ALL = ::T.let(nil, ::T.untyped)
+end
+
+module RSpec::Mocks::ArgumentMatchers
+  extend ::T::Sig
+end
+
+module RSpec::Mocks::ExampleMethods::ExpectHost
+  extend ::T::Sig
+end
+
+module RSpec::Mocks::ExampleMethods
+  extend ::T::Sig
+end
+
+class RSpec::Mocks::ExpectChain
+end
+
+class RSpec::Mocks::ExpectChain
+  def self.expect_chain_on(object, *chain, &blk); end
+end
+
+module RSpec::Mocks::ExpectationTargetMethods
+  extend ::T::Sig
+end
+
+class RSpec::Mocks::MarshalExtension
+end
+
+class RSpec::Mocks::MarshalExtension
+  def self.patch!(); end
+
+  def self.unpatch!(); end
+end
+
+class RSpec::Mocks::Matchers::HaveReceived
+  include ::RSpec::Mocks::Matchers::Matcher
+  def at_least(*args); end
+
+  def at_most(*args); end
+
+  def description(); end
+
+  def does_not_match?(subject); end
+
+  def exactly(*args); end
+
+  def failure_message(); end
+
+  def failure_message_when_negated(); end
+
+  def initialize(method_name, &block); end
+
+  def matches?(subject, &block); end
+
+  def name(); end
+
+  def once(*args); end
+
+  def ordered(*args); end
+
+  def setup_allowance(_subject, &_block); end
+
+  def setup_any_instance_allowance(_subject, &_block); end
+
+  def setup_any_instance_expectation(_subject, &_block); end
+
+  def setup_any_instance_negative_expectation(_subject, &_block); end
+
+  def setup_expectation(subject, &block); end
+
+  def setup_negative_expectation(subject, &block); end
+
+  def thrice(*args); end
+
+  def times(*args); end
+
+  def twice(*args); end
+
+  def with(*args); end
+  ARGS_CONSTRAINTS = ::T.let(nil, ::T.untyped)
+  CONSTRAINTS = ::T.let(nil, ::T.untyped)
+  COUNT_CONSTRAINTS = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Mocks::Matchers::HaveReceived
+end
+
+module RSpec::Mocks::Matchers::Matcher
+  extend ::T::Sig
+end
+
+class RSpec::Mocks::Matchers::Receive
+  include ::RSpec::Mocks::Matchers::Matcher
+  def and_call_original(*args, &block); end
+
+  def and_raise(*args, &block); end
+
+  def and_return(*args, &block); end
+
+  def and_throw(*args, &block); end
+
+  def and_wrap_original(*args, &block); end
+
+  def and_yield(*args, &block); end
+
+  def at_least(*args, &block); end
+
+  def at_most(*args, &block); end
+
+  def description(); end
+
+  def does_not_match?(subject, &block); end
+
+  def exactly(*args, &block); end
+
+  def initialize(message, block); end
+
+  def matches?(subject, &block); end
+
+  def name(); end
+
+  def never(*args, &block); end
+
+  def once(*args, &block); end
+
+  def ordered(*args, &block); end
+
+  def setup_allowance(subject, &block); end
+
+  def setup_any_instance_allowance(subject, &block); end
+
+  def setup_any_instance_expectation(subject, &block); end
+
+  def setup_any_instance_negative_expectation(subject, &block); end
+
+  def setup_expectation(subject, &block); end
+
+  def setup_negative_expectation(subject, &block); end
+
+  def thrice(*args, &block); end
+
+  def times(*args, &block); end
+
+  def twice(*args, &block); end
+
+  def with(*args, &block); end
+end
+
+class RSpec::Mocks::Matchers::Receive::DefaultDescribable
+  def description_for(verb); end
+
+  def initialize(message); end
+end
+
+class RSpec::Mocks::Matchers::Receive::DefaultDescribable
+end
+
+class RSpec::Mocks::Matchers::Receive
+end
+
+class RSpec::Mocks::Matchers::ReceiveMessageChain
+  include ::RSpec::Mocks::Matchers::Matcher
+  def and_call_original(*args, &block); end
+
+  def and_raise(*args, &block); end
+
+  def and_return(*args, &block); end
+
+  def and_throw(*args, &block); end
+
+  def and_yield(*args, &block); end
+
+  def description(); end
+
+  def does_not_match?(*_args); end
+
+  def initialize(chain, &block); end
+
+  def matches?(subject, &block); end
+
+  def name(); end
+
+  def setup_allowance(subject, &block); end
+
+  def setup_any_instance_allowance(subject, &block); end
+
+  def setup_any_instance_expectation(subject, &block); end
+
+  def setup_expectation(subject, &block); end
+
+  def setup_negative_expectation(*_args); end
+
+  def with(*args, &block); end
+end
+
+class RSpec::Mocks::Matchers::ReceiveMessageChain
+end
+
+class RSpec::Mocks::Matchers::ReceiveMessages
+  include ::RSpec::Mocks::Matchers::Matcher
+  def description(); end
+
+  def does_not_match?(_subject); end
+
+  def initialize(message_return_value_hash); end
+
+  def matches?(subject); end
+
+  def name(); end
+
+  def setup_allowance(subject); end
+
+  def setup_any_instance_allowance(subject); end
+
+  def setup_any_instance_expectation(subject); end
+
+  def setup_expectation(subject); end
+
+  def setup_negative_expectation(_subject); end
+
+  def warn_about_block(); end
+end
+
+class RSpec::Mocks::Matchers::ReceiveMessages
+end
+
+module RSpec::Mocks::Matchers
+  extend ::T::Sig
+end
+
+class RSpec::Mocks::MessageChain
+  def block(); end
+
+  def chain(); end
+
+  def initialize(object, *chain, &blk); end
+
+  def object(); end
+
+  def setup_chain(); end
+end
+
+class RSpec::Mocks::MessageChain
+end
+
+module RSpec::Mocks::MessageExpectation::ImplementationDetails
+  extend ::T::Sig
+end
+
+class RSpec::Mocks::ObjectReference
+  MODULE_NAME_METHOD = ::T.let(nil, ::T.untyped)
+end
+
+module RSpec::Mocks::ObjectVerifyingDoubleMethods
+  extend ::T::Sig
+end
+
+module RSpec::Mocks::PartialClassDoubleProxyMethods
+  extend ::T::Sig
+end
+
+class RSpec::Mocks::Proxy
+  DEFAULT_MESSAGE_EXPECTATION_OPTS = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Mocks::StubChain
+end
+
+class RSpec::Mocks::StubChain
+  def self.stub_chain_on(object, *chain, &blk); end
+end
+
+module RSpec::Mocks::Syntax
+  extend ::T::Sig
+end
+
+module RSpec::Mocks::TargetDelegationClassMethods
+  extend ::T::Sig
+end
+
+module RSpec::Mocks::TargetDelegationInstanceMethods
+  extend ::T::Sig
+end
+
+module RSpec::Mocks::TestDouble
+  extend ::T::Sig
+end
+
+module RSpec::Mocks::TestDoubleFormatter
+  extend ::T::Sig
+end
+
+module RSpec::Mocks::VerifyingDouble::SilentIO
+  extend ::T::Sig
+end
+
+module RSpec::Mocks::VerifyingDouble
+  extend ::T::Sig
+end
+
+module RSpec::Mocks::VerifyingProxyMethods
+  extend ::T::Sig
+end
+
+module RSpec::Mocks::Version
+  STRING = ::T.let(nil, ::T.untyped)
+end
+
+module RSpec::Mocks::Version
+  extend ::T::Sig
+end
+
+module RSpec::Mocks
+  extend ::T::Sig
+end
+
 RSpec::SharedContext = RSpec::Core::SharedContext
 
 module RSpec::Support
@@ -8817,10 +10710,35 @@ class RSpec::Support::EncodedString
   UTF_8 = ::T.let(nil, ::T.untyped)
 end
 
+module RSpec::Support::FuzzyMatcher
+  extend ::T::Sig
+end
+
+class RSpec::Support::MethodSignature
+  INFINITY = ::T.let(nil, ::T.untyped)
+end
+
 RSpec::Support::Mutex = Thread::Mutex
 
 module RSpec::Support::OS
   extend ::T::Sig
+end
+
+class RSpec::Support::ObjectFormatter
+  ELLIPSIS = ::T.let(nil, ::T.untyped)
+  INSPECTOR_CLASSES = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Support::ObjectFormatter::DateTimeInspector
+  FORMAT = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Support::ObjectFormatter::TimeInspector
+  FORMAT = ::T.let(nil, ::T.untyped)
+end
+
+class RSpec::Support::ObjectFormatter::UninspectableObjectInspector
+  OBJECT_ID_FORMAT = ::T.let(nil, ::T.untyped)
 end
 
 module RSpec::Support::RecursiveConstMethods
@@ -8834,6 +10752,8 @@ end
 module RSpec::Support::RubyFeatures
   extend ::T::Sig
 end
+
+RSpec::Support::StrictSignatureVerifier = RSpec::Support::MethodSignatureVerifier
 
 module RSpec::Support::Version
   STRING = ::T.let(nil, ::T.untyped)
@@ -8849,15 +10769,6 @@ end
 
 module RSpec::Support
   extend ::T::Sig
-  def self.deregister_matcher_definition(&block); end
-
-  def self.is_a_matcher?(object); end
-
-  def self.matcher_definitions(); end
-
-  def self.register_matcher_definition(&block); end
-
-  def self.rspec_description_for_object(object); end
 end
 
 module RSpec::Version
@@ -9019,7 +10930,18 @@ end
 
 class Random
   extend ::T::Sig
+  extend ::Random::Formatter
+  def self.bytes(_); end
+
   def self.urandom(_); end
+end
+
+class Range
+  def %(_); end
+
+  def entries(); end
+
+  def to_a(); end
 end
 
 class Range
@@ -9038,6 +10960,8 @@ module RbConfig
   extend ::T::Sig
   def self.expand(val, config=T.unsafe(nil)); end
 
+  def self.fire_update!(key, val, mkconf=T.unsafe(nil), conf=T.unsafe(nil)); end
+
   def self.ruby(); end
 end
 
@@ -9052,6 +10976,37 @@ end
 
 class RegexpError
   extend ::T::Sig
+end
+
+module RubyVM::AbstractSyntaxTree
+end
+
+class RubyVM::AbstractSyntaxTree::Node
+  def children(); end
+
+  def first_column(); end
+
+  def first_lineno(); end
+
+  def last_column(); end
+
+  def last_lineno(); end
+
+  def pretty_print_children(q, names=T.unsafe(nil)); end
+
+  def type(); end
+end
+
+class RubyVM::AbstractSyntaxTree::Node
+end
+
+module RubyVM::AbstractSyntaxTree
+  extend ::T::Sig
+  def self.of(_); end
+
+  def self.parse(_); end
+
+  def self.parse_file(_); end
 end
 
 class RubyVM::InstructionSequence
@@ -9101,8 +11056,22 @@ class RubyVM::InstructionSequence
   def self.of(_); end
 end
 
+module RubyVM::MJIT
+end
+
+module RubyVM::MJIT
+  extend ::T::Sig
+  def self.enabled?(); end
+
+  def self.pause(*_); end
+
+  def self.resume(); end
+end
+
 class RubyVM
   extend ::T::Sig
+  def self.resolve_feature_path(_); end
+
   def self.stat(*_); end
 end
 
@@ -9132,6 +11101,8 @@ class Set
   def divide(&func); end
 
   def eql?(o); end
+
+  def filter!(&block); end
 
   def flatten_merge(set, seen=T.unsafe(nil)); end
 
@@ -9181,7 +11152,84 @@ class SignalException
   extend ::T::Sig
 end
 
+module SimpleCov
+  VERSION = ::T.let(nil, ::T.untyped)
+end
+
+module SimpleCov::CommandGuesser
+  extend ::T::Sig
+end
+
+module SimpleCov::Configuration
+  extend ::T::Sig
+end
+
+module SimpleCov::ExitCodes
+  EXCEPTION = ::T.let(nil, ::T.untyped)
+  MAXIMUM_COVERAGE_DROP = ::T.let(nil, ::T.untyped)
+  MINIMUM_COVERAGE = ::T.let(nil, ::T.untyped)
+  SUCCESS = ::T.let(nil, ::T.untyped)
+end
+
+module SimpleCov::ExitCodes
+  extend ::T::Sig
+end
+
+class SimpleCov::Formatter::HTMLFormatter
+  VERSION = ::T.let(nil, ::T.untyped)
+end
+
+module SimpleCov::Formatter::MultiFormatter::InstanceMethods
+  extend ::T::Sig
+end
+
+module SimpleCov::Formatter
+  extend ::T::Sig
+end
+
+module SimpleCov::LastRun
+  extend ::T::Sig
+end
+
+class SimpleCov::LinesClassifier
+  COMMENT_LINE = ::T.let(nil, ::T.untyped)
+  NOT_RELEVANT = ::T.let(nil, ::T.untyped)
+  RELEVANT = ::T.let(nil, ::T.untyped)
+  WHITESPACE_LINE = ::T.let(nil, ::T.untyped)
+  WHITESPACE_OR_COMMENT_LINE = ::T.let(nil, ::T.untyped)
+end
+
+module SimpleCov::RawCoverage
+  extend ::T::Sig
+end
+
+module SimpleCov::ResultMerger
+  extend ::T::Sig
+end
+
+module SimpleCov
+  extend ::T::Sig
+end
+
 class SimpleDelegator
+  extend ::T::Sig
+end
+
+module SingleForwardable
+  def def_delegator(accessor, method, ali=T.unsafe(nil)); end
+
+  def def_delegators(accessor, *methods); end
+
+  def def_single_delegator(accessor, method, ali=T.unsafe(nil)); end
+
+  def def_single_delegators(accessor, *methods); end
+
+  def delegate(hash); end
+
+  def single_delegate(hash); end
+end
+
+module SingleForwardable
   extend ::T::Sig
 end
 
@@ -9620,6 +11668,18 @@ class Sorbet
   extend ::T::Sig
 end
 
+module Sord::Logging
+  extend ::T::Sig
+end
+
+module Sord::Resolver
+  extend ::T::Sig
+end
+
+module Sord::TypeConverter
+  extend ::T::Sig
+end
+
 module Sord
   extend ::T::Sig
 end
@@ -9816,6 +11876,8 @@ class Struct
   def dig(*_); end
 
   def each_pair(); end
+
+  def filter(*_); end
 
   def length(); end
 
@@ -10100,7 +12162,15 @@ class Time
 end
 
 class TracePoint
+  def __enable(_, _1); end
+
+  def eval_script(); end
+
   def event(); end
+
+  def instruction_sequence(); end
+
+  def parameters(); end
 end
 
 class TracePoint
@@ -10158,6 +12228,21 @@ end
 class URI::FTP
   extend ::T::Sig
   def self.new2(user, password, host, port, path, typecode=T.unsafe(nil), arg_check=T.unsafe(nil)); end
+end
+
+class URI::File
+  def check_password(user); end
+
+  def check_user(user); end
+
+  def check_userinfo(user); end
+
+  def set_userinfo(v); end
+  COMPONENT = ::T.let(nil, ::T.untyped)
+  DEFAULT_PORT = ::T.let(nil, ::T.untyped)
+end
+
+class URI::File
 end
 
 class URI::Generic
@@ -10488,6 +12573,8 @@ module Warning
   extend ::T::Sig
   extend ::Warning
 end
+
+YAML = Psych
 
 module YARD
   CONFIG_DIR = ::T.let(nil, ::T.untyped)
@@ -13431,7 +15518,7 @@ end
 class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP
   def add_html(tag, name); end
 
-  def add_special(pattern, name); end
+  def add_regexp_handling(pattern, name); end
 
   def add_word_pair(start, stop, name); end
 
@@ -13472,7 +15559,7 @@ end
 class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::AttributeManager
   def add_html(tag, name); end
 
-  def add_special(pattern, name); end
+  def add_regexp_handling(pattern, name); end
 
   def add_word_pair(start, stop, name); end
 
@@ -13488,7 +15575,7 @@ class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::AttributeManager
 
   def convert_html(str, attrs); end
 
-  def convert_specials(str, attrs); end
+  def convert_regexp_handlings(str, attrs); end
 
   def copy_string(start_pos, end_pos); end
 
@@ -13504,7 +15591,7 @@ class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::AttributeManager
 
   def protectable(); end
 
-  def special(); end
+  def regexp_handlings(); end
 
   def split_into_flow(); end
 
@@ -13526,7 +15613,7 @@ class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::Attributes
 
   def each_name_of(bitmap); end
 
-  def special(); end
+  def regexp_handling(); end
 end
 
 class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::Attributes
@@ -13587,9 +15674,9 @@ end
 class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::Formatter
   def accept_document(document); end
 
-  def add_special_RDOCLINK(); end
+  def add_regexp_handling_RDOCLINK(); end
 
-  def add_special_TIDYLINK(); end
+  def add_regexp_handling_TIDYLINK(); end
 
   def add_tag(name, start, stop); end
 
@@ -13599,7 +15686,7 @@ class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::Formatter
 
   def convert_flow(flow); end
 
-  def convert_special(special); end
+  def convert_regexp_handling(target); end
 
   def convert_string(string); end
 
@@ -13640,13 +15727,6 @@ end
 
 class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::Formatter
   def self.gen_relative_url(path, target); end
-end
-
-class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::FormatterTestCase
-end
-
-class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::FormatterTestCase
-  def self.add_visitor_tests(); end
 end
 
 class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::HardBreak
@@ -13873,14 +15953,7 @@ end
 class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::Raw
 end
 
-class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::Rule
-  def accept(visitor); end
-end
-
-class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::Rule
-end
-
-class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::Special
+class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::RegexpHandling
   def ==(o); end
 
   def initialize(type, text); end
@@ -13892,14 +15965,14 @@ class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::Special
   def type(); end
 end
 
-class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::Special
+class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::RegexpHandling
 end
 
-class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::TextFormatterTestCase
+class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::Rule
+  def accept(visitor); end
 end
 
-class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::TextFormatterTestCase
-  def self.add_text_tests(); end
+class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::Rule
 end
 
 class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::ToAnsi
@@ -13954,13 +16027,13 @@ class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::ToHtml
 
   def handle_RDOCLINK(url); end
 
-  def handle_special_HARD_BREAK(special); end
+  def handle_regexp_HARD_BREAK(target); end
 
-  def handle_special_HYPERLINK(special); end
+  def handle_regexp_HYPERLINK(target); end
 
-  def handle_special_RDOCLINK(special); end
+  def handle_regexp_RDOCLINK(target); end
 
-  def handle_special_TIDYLINK(special); end
+  def handle_regexp_TIDYLINK(target); end
 
   def html_list_name(list_type, open_tag); end
 
@@ -13992,13 +16065,13 @@ class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::ToHtmlCrossref
 
   def context=(context); end
 
-  def cross_reference(name, text=T.unsafe(nil)); end
+  def cross_reference(name, text=T.unsafe(nil), code=T.unsafe(nil)); end
 
-  def handle_special_CROSSREF(special); end
+  def handle_regexp_CROSSREF(target); end
 
   def initialize(options, from_path, context, markup=T.unsafe(nil)); end
 
-  def link(name, text); end
+  def link(name, text, code=T.unsafe(nil)); end
 
   def show_hash(); end
 
@@ -14023,7 +16096,7 @@ class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::ToHtmlSnippet
 
   def characters(); end
 
-  def handle_special_CROSSREF(special); end
+  def handle_regexp_CROSSREF(target); end
 
   def initialize(options, characters=T.unsafe(nil), paragraphs=T.unsafe(nil), markup=T.unsafe(nil)); end
 
@@ -14097,11 +16170,11 @@ class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::ToLabel
 
   def end_accepting(*node); end
 
-  def handle_special_CROSSREF(special); end
+  def handle_regexp_CROSSREF(target); end
 
-  def handle_special_HARD_BREAK(*node); end
+  def handle_regexp_HARD_BREAK(*node); end
 
-  def handle_special_TIDYLINK(special); end
+  def handle_regexp_TIDYLINK(target); end
 
   def initialize(markup=T.unsafe(nil)); end
 
@@ -14118,9 +16191,9 @@ class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::ToMarkdown
 
   def handle_rdoc_link(url); end
 
-  def handle_special_RDOCLINK(special); end
+  def handle_regexp_RDOCLINK(target); end
 
-  def handle_special_TIDYLINK(special); end
+  def handle_regexp_TIDYLINK(target); end
 end
 
 class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::ToMarkdown
@@ -14155,9 +16228,9 @@ class YARD::Templates::Helpers::Markup::RDocMarkup::MARKUP::ToRdoc
 
   def end_accepting(); end
 
-  def handle_special_HARD_BREAK(special); end
+  def handle_regexp_HARD_BREAK(target); end
 
-  def handle_special_SUPPRESSED_CROSSREF(special); end
+  def handle_regexp_SUPPRESSED_CROSSREF(target); end
 
   def indent(); end
 

--- a/sorbet/rbi/sorbet-typed/lib/bundler/all/bundler.rbi
+++ b/sorbet/rbi/sorbet-typed/lib/bundler/all/bundler.rbi
@@ -5,7 +5,7 @@
 #
 #   https://github.com/sorbet/sorbet-typed/edit/master/lib/bundler/all/bundler.rbi
 #
-# typed: true
+# typed: strict
 
 module Bundler
   FREEBSD = ::T.let(nil, ::T.untyped)
@@ -4137,8 +4137,13 @@ class Bundler::Molinillo::DependencyGraph
   end
   def detach_vertex_named(name); end
 
-  sig {returns(::T.untyped)}
-  def each(); end
+  sig do
+    params(
+      blk: ::T.untyped,
+    )
+    .returns(::T.untyped)
+  end
+  def each(&blk); end
 
   sig {returns(::T.untyped)}
   def initialize(); end
@@ -4531,8 +4536,13 @@ class Bundler::Molinillo::DependencyGraph::Log
   end
   def detach_vertex_named(graph, name); end
 
-  sig {returns(::T.untyped)}
-  def each(); end
+  sig do
+    params(
+      blk: ::T.untyped,
+    )
+    .returns(::T.untyped)
+  end
+  def each(&blk); end
 
   sig {returns(::T.untyped)}
   def initialize(); end

--- a/sorbet/rbi/sorbet-typed/lib/ruby/all/open3.rbi
+++ b/sorbet/rbi/sorbet-typed/lib/ruby/all/open3.rbi
@@ -5,7 +5,7 @@
 #
 #   https://github.com/sorbet/sorbet-typed/edit/master/lib/ruby/all/open3.rbi
 #
-# typed: strong
+# typed: strict
 
 module Open3
   sig do

--- a/sorbet/rbi/sorbet-typed/lib/ruby/all/resolv.rbi
+++ b/sorbet/rbi/sorbet-typed/lib/ruby/all/resolv.rbi
@@ -5,7 +5,7 @@
 #
 #   https://github.com/sorbet/sorbet-typed/edit/master/lib/ruby/all/resolv.rbi
 #
-# typed: strong
+# typed: strict
 
 class Resolv
   sig { params(name: String).returns(String) }

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 require 'yard'
 
 describe Sord::RbiGenerator do

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: ignore
 require 'yard'
 
 describe Sord::Resolver do

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -1,3 +1,4 @@
+# typed: ignore
 describe Sord::TypeConverter do
   before do
     Sord::Logging.silent = true


### PR DESCRIPTION
This PR does a few things:

- Adds YARD documentation wherever it was missing.
- Regenerates `rbi/sord.rbi` with the new type information.
- Updates sorbet-typed, hidden-definitions, and gems in `sorbet/rbi/`

There's now only one T.untyped in all of `sord.rbi`, and that's because of #66.