### PR TITLE
Handle @option tags

### DIFF
--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -167,7 +167,9 @@ module Sord
           options_array = []
           tags.each do |tag|
             option_type = TypeConverter.yard_to_sorbet(tag.pair.types, meth, indent_level, @replace_errors_with_untyped)
-            options_array << "#{tag.pair.name}: #{option_type}"
+            option_name = tag.pair.name
+            option_name = option_name.gsub(':', '') if option_name.start_with?(':')
+            options_array << "#{option_name}: #{option_type}"
           end
 
           options << {

--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -166,7 +166,8 @@ module Sord
           # Create an array of strings like ['foo: String', 'bar: Integer']
           options_array = []
           tags.each do |tag|
-            options_array << "#{tag.pair.name}: #{TypeConverter.yard_to_sorbet(tag.pair.types, meth, indent_level, @replace_errors_with_untyped)}"
+            option_type = TypeConverter.yard_to_sorbet(tag.pair.types, meth, indent_level, @replace_errors_with_untyped)
+            options_array << "#{tag.pair.name}: #{option_type}"
           end
 
           options << {

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -397,4 +397,23 @@ describe Sord::RbiGenerator do
       end
     RUBY
   end
+
+  it 'handles option tags with symbol names' do
+    YARD.parse_string(<<-RUBY)
+      module A
+        # @option opts [String] :bar
+        # @option opts [Integer] :baz
+        # @return [void]
+        def foo(opts); end
+      end
+    RUBY
+
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      module A
+        sig { params(opts: { bar: String, baz: Integer }).void }
+        def foo(opts); end
+      end
+    RUBY
+  end
 end

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -356,4 +356,45 @@ describe Sord::RbiGenerator do
       end
     RUBY
   end
+
+  it 'handles option tags for multiple params' do
+    YARD.parse_string(<<-RUBY)
+      module A
+        # @option opts [String] bar
+        # @option opts [Integer] baz
+        # @option other [Symbol] qux
+        # @option other [Array<String>] quux
+        # @return [void]
+        def foo(opts, other); end
+      end
+    RUBY
+
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      module A
+        sig { params(opts: { bar: String, baz: Integer }, other: { qux: Symbol, quux: T::Array[String] }).void }
+        def foo(opts, other); end
+      end
+    RUBY
+  end
+
+  it 'handles option tags along with other params' do
+    YARD.parse_string(<<-RUBY)
+      module A
+        # @param [Array<Symbol>] foo
+        # @option opts [String] bar
+        # @option opts [Integer] baz
+        # @return [void]
+        def foo(foo, opts); end
+      end
+    RUBY
+
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      module A
+        sig { params(foo: T::Array[Symbol], opts: { bar: String, baz: Integer }).void }
+        def foo(foo, opts); end
+      end
+    RUBY
+  end
 end

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -321,19 +321,19 @@ describe Sord::RbiGenerator do
   it 'handles option tags' do
     YARD.parse_string(<<-RUBY)
       module A
-        # @param [Hash] options
-        # @option options [String] bar
-        # @option options [Integer] baz
+        # @param [Hash] opts
+        # @option opts [String] bar
+        # @option opts [Integer] baz
         # @return [void]
-        def foo(options); end
+        def foo(opts); end
       end
     RUBY
 
     expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       module A
-        sig { params(options: { bar: String, baz: Integer }).void }
-        def foo(options); end
+        sig { params(opts: { bar: String, baz: Integer }).void }
+        def foo(opts); end
       end
     RUBY
   end
@@ -341,18 +341,18 @@ describe Sord::RbiGenerator do
   it 'handles option tags without a param tag' do
     YARD.parse_string(<<-RUBY)
       module A
-        # @option options [String] bar
-        # @option options [Integer] baz
+        # @option opts [String] bar
+        # @option opts [Integer] baz
         # @return [void]
-        def foo(options); end
+        def foo(opts); end
       end
     RUBY
 
     expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       module A
-        sig { params(options: { bar: String, baz: Integer }).void }
-        def foo(options); end
+        sig { params(opts: { bar: String, baz: Integer }).void }
+        def foo(opts); end
       end
     RUBY
   end

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -317,4 +317,43 @@ describe Sord::RbiGenerator do
       end
     RUBY
   end
+
+  it 'handles option tags' do
+    YARD.parse_string(<<-RUBY)
+      module A
+        # @param [Hash] options
+        # @option options [String] bar
+        # @option options [Integer] baz
+        # @return [void]
+        def foo(options); end
+      end
+    RUBY
+
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      module A
+        sig { params(options: { bar: String, baz: Integer }).void }
+        def foo(options); end
+      end
+    RUBY
+  end
+
+  it 'handles option tags without a param tag' do
+    YARD.parse_string(<<-RUBY)
+      module A
+        # @option options [String] bar
+        # @option options [Integer] baz
+        # @return [void]
+        def foo(options); end
+      end
+    RUBY
+
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      module A
+        sig { params(options: { bar: String, baz: Integer }).void }
+        def foo(options); end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Implements #59.

Input:

```ruby
module A
  # @param [Hash] opts
  # @option opts [String] bar
  # @option opts [Integer] baz
  # @return [void]
  def foo(opts); end
end
```

Output (Before):

```ruby
# typed: strong
module A
  sig { params(opts: Hash).void }
  def foo(opts); end
end
```

Output (After):

```ruby
# typed: strong
module A
  sig { params(opts: { bar: String, baz: Integer }).void }
  def foo(opts); end
end
```

Adds five test cases.

I didn't update `sord.rbi` as part of this so as not to conflict with #67, but you should probably regenerate it after merging this (if you merge it). Then the keys available in the `options` hash for the `RbiGenerator` initializer will be explicitly specified :)