### PR TITLE
Add a clean option to seed and reseed tasks.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,14 +54,18 @@ namespace :examples do
   end
 
   desc 'Regenerate the rbi files in sord_examples.'
-  task :reseed do
+  task :reseed, [:clean] do |t, args|
     FileUtils.cd 'sord_examples'
 
     REPOS.keys.each do |name|
       FileUtils.cd name.to_s
       puts "Regenerating rbi file for #{name}..."
       Bundler.with_clean_env do
-        system("bundle exec sord ../#{name}.rbi --no-regenerate")
+        if args[:clean]
+          system("bundle exec sord ../#{name}.rbi --no-regenerate --no-comments --replace-errors-with-untyped")
+        else
+          system("bundle exec sord ../#{name}.rbi --no-regenerate")
+        end
       end
       FileUtils.cd '..'
     end

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ namespace :examples do
   require 'colorize'
 
   desc "Clone git repositories and run Sord on them as examples"
-  task :seed do
+  task :seed, [:clean] do |t, args|
     if File.directory?('sord_examples')
       puts 'sord_examples directory already exists, please delete the directory or run a reseed!'.red
       exit
@@ -44,7 +44,11 @@ namespace :examples do
         system('bundle install')
         # Generate sri
         puts "Generating rbi for #{name}..."
-        system("bundle exec sord ../#{name}.rbi")
+        if args[:clean]
+          system("bundle exec sord ../#{name}.rbi --no-comments --replace-errors-with-untyped")
+        else
+          system("bundle exec sord ../#{name}.rbi")
+        end
         puts "#{name}.rbi generated!"
         FileUtils.cd '..'
       end


### PR DESCRIPTION
This doesn't change `bundle exec rake examples:seed` or `bundle exec rake examples:reseed`.

`bundle exec rake examples:seed[true]` and `bundle exec rake examples:reseed[true]` will run Sord with `--no-comments` and `--replace-errors-with-untyped` enabled.