### PR TITLE
Add examples:typecheck which will typecheck each rbi file in sord_examples

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -87,7 +87,7 @@ namespace :examples do
   task :typecheck do
     REPOS.each do |name, url|
       Bundler.with_clean_env do
-        cmd = "srb tc sord_examples/#{name}.rbi"
+        cmd = "srb tc sord_examples/#{name}.rbi --ignore sord.rbi"
         puts cmd
         system(cmd)
       end

--- a/Rakefile
+++ b/Rakefile
@@ -82,5 +82,15 @@ namespace :examples do
     FileUtils.rm_rf 'sord_examples' if File.directory?('sord_examples')
     puts 'Reset complete.'.green
   end
-end
 
+  desc 'Typecheck each of the sord_examples rbi files.'
+  task :typecheck do
+    REPOS.each do |name, url|
+      Bundler.with_clean_env do
+        cmd = "srb tc sord_examples/#{name}.rbi"
+        puts cmd
+        system(cmd)
+      end
+    end
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -87,6 +87,7 @@ namespace :examples do
   task :typecheck do
     REPOS.each do |name, url|
       Bundler.with_clean_env do
+        8.times { puts }
         cmd = "srb tc sord_examples/#{name}.rbi --ignore sord.rbi"
         puts cmd
         system(cmd)


### PR DESCRIPTION
This is pretty useful for seeing where we're at in terms of the signatures we generate, I've already found a few issues using this.

It might be good to add some way to collect just the # of errors and display them at the end (I don't think sorbet takes a flag to only output the # of errors, unfortunately).