### PR TITLE
Migrate to using Parlour for generation

### DIFF
--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -66,7 +66,6 @@ module Sord
     # @param [YARD::CodeObjects::Base] item
     # @return [Integer]
     def add_mixins(item)
-      p "YARD: #{[item.instance_mixins, item.class_mixins]}"
       item.instance_mixins.reverse_each do |i|
         @current_object.add_include(i.name.to_s)
       end

--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -175,10 +175,19 @@ module Sord
         parlour_params = parameter_names_and_defaults_to_tags
           .zip(parameter_types)
           .map do |((name, default), _), type|
-            Parlour::RbiGenerator::Parameter.new(name.to_s, type: type, default: default)
+            Parlour::RbiGenerator::Parameter.new(
+              name: name.to_s,
+              type: type,
+              default: default
+            )
           end
 
-        @current_object.create_method(meth.name.to_s, parlour_params, returns, class_method: meth.scope == :class)
+        @current_object.create_method(
+          name: meth.name.to_s, 
+          parameters: parlour_params,
+          returns: returns,
+          class_method: meth.scope == :class
+        )
       end
     end
 
@@ -195,8 +204,8 @@ module Sord
 
       parent = @current_object
       @current_object = item.type == :class \
-        ? parent.create_class(item.name.to_s, superclass: superclass)
-        : parent.create_module(item.name.to_s)
+        ? parent.create_class(name: item.name.to_s, superclass: superclass)
+        : parent.create_module(name: item.name.to_s)
 
       add_mixins(item)
       add_methods(item)

--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -44,8 +44,7 @@ module Sord
       # Hook the logger so that warnings are collected
       Logging.add_hook do |type, msg, item|
         # TODO: is it possible to get line numbers here?
-        warnings << [msg, item, rbi_contents.length] \
-          if type == :warn
+        warnings << [msg, item, 0] if type == :warn
       end
     end
 

--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -3,13 +3,11 @@ require 'yard'
 require 'sord/type_converter'
 require 'colorize'
 require 'sord/logging'
+require 'parlour'
 
 module Sord
   # Converts the current working directory's YARD registry into an RBI file.
-  class RbiGenerator
-    # @return [Array<String>] The lines of the generated RBI file so far.
-    attr_reader :rbi_contents
-    
+  class RbiGenerator    
     # @return [Integer] The number of objects this generator has processed so 
     #   far.
     def object_count
@@ -21,11 +19,6 @@ module Sord
     #   [message, item, line].
     attr_reader :warnings
 
-    # @return [Boolean] A boolean indicating whether the next item is the first
-    #   in its namespace. This is used to determine whether to insert a blank
-    #   line before it or not.
-    attr_accessor :next_item_is_first_in_namespace
-
     # Create a new RBI generator.
     # @param [Hash] options
     # @option options [Integer] break_params
@@ -33,21 +26,21 @@ module Sord
     # @option options [Boolean] comments
     # @return [void]
     def initialize(options)
-      @rbi_contents = ['# typed: strong']
       @namespace_count = 0
       @method_count = 0
       @break_params = options[:break_params]
       @replace_errors_with_untyped = options[:replace_errors_with_untyped]
+      @parlour = Parlour::RbiGenerator.new(break_params: @break_params)
       @warnings = []
-      @next_item_is_first_in_namespace = true
+      @current_object = @parlour.root
 
       # Hook the logger so that messages are added as comments to the RBI file
-      Logging.add_hook do |type, msg, item, indent_level = 0|
-        rbi_contents << "#{'  ' * (indent_level + 1)}# sord #{type} - #{msg}"
+      Logging.add_hook do |type, msg, item|
+        @current_object.add_comment_to_next_child("sord #{type} - #{msg}")
       end if options[:comments]
 
       # Hook the logger so that warnings are collected
-      Logging.add_hook do |type, msg, item, indent_level = 0|
+      Logging.add_hook do |type, msg, item|
         warnings << [msg, item, rbi_contents.length] \
           if type == :warn
       end
@@ -65,65 +58,27 @@ module Sord
       @method_count += 1
     end
 
-    # Adds a single blank line to the RBI file, unless this item is the first
-    # in its namespace.
-    # @return [void]
-    def add_blank
-      rbi_contents << '' unless next_item_is_first_in_namespace
-      self.next_item_is_first_in_namespace = false
-    end
-
     # Given a YARD CodeObject, add lines defining its mixins (that is, extends
     # and includes) to the current RBI file. Returns the number of mixins.
     # @param [YARD::CodeObjects::Base] item
-    # @param [Integer] indent_level
     # @return [Integer]
-    def add_mixins(item, indent_level)
-      includes = item.instance_mixins
-      extends = item.class_mixins
-
-      extends.reverse_each do |this_extend|
-        rbi_contents << "#{'  ' * (indent_level + 1)}extend #{this_extend.path}"
+    def add_mixins(item)
+      p "YARD: #{[item.instance_mixins, item.class_mixins]}"
+      item.instance_mixins.reverse_each do |i|
+        @current_object.add_include(i.name.to_s)
       end
-      includes.reverse_each do |this_include|
-        rbi_contents << "#{'  ' * (indent_level + 1)}include #{this_include.path}"
+      item.class_mixins.reverse_each do |e|
+        @current_object.add_extend(e.name.to_s)
       end
 
-      extends.length + includes.length
-    end
-
-    # Given an array of parameters and a return type, inserts the signature for
-    # a method with those properties into the current RBI file.
-    # @param [Array<String>] params
-    # @param [String] returns
-    # @param [Integer] indent_level
-    # @return [void]
-    def add_signature(params, returns, indent_level)
-      if params.empty?
-        rbi_contents << "#{'  ' * (indent_level + 1)}sig { #{returns} }"
-        return
-      end
-
-      if params.length >= @break_params
-        rbi_contents << "#{'  ' * (indent_level + 1)}sig do"
-        rbi_contents << "#{'  ' * (indent_level + 2)}params("
-        params.each.with_index do |param, i|
-          terminator = params.length - 1 == i ? '' : ','
-          rbi_contents << "#{'  ' * (indent_level + 3)}#{param}#{terminator}"
-        end
-        rbi_contents << "#{'  ' * (indent_level + 2)}).#{returns}"
-        rbi_contents << "#{'  ' * (indent_level + 1)}end"
-      else
-        rbi_contents << "#{'  ' * (indent_level + 1)}sig { params(#{params.join(', ')}).#{returns} }"
-      end
+      item.instance_mixins.length + item.class_mixins.length
     end
 
     # Given a YARD NamespaceObject, add lines defining its methods and their
     # signatures to the current RBI file.
     # @param [YARD::CodeObjects::NamespaceObject] item
-    # @param [Integer] indent_level
     # @return [void]
-    def add_methods(item, indent_level)
+    def add_methods(item)
       item.meths.each do |meth|
         count_method
 
@@ -133,39 +88,20 @@ module Sord
           next
         end
 
-        add_blank
-
-        parameter_list = meth.parameters.map do |name, default|
-          # Handle these three main cases:
-          # - def method(param) or def method(param:)
-          # - def method(param: 'default')
-          # - def method(param = 'default')
-          if default.nil?
-            "#{name}"
-          elsif !default.nil? && name.end_with?(':')
-            "#{name} #{default}"
-          else
-            "#{name} = #{default}"
-          end
-        end.join(", ")
-
         # This is better than iterating over YARD's "@param" tags directly 
         # because it includes parameters without documentation
         # (The gsubs allow for better splat-argument compatibility)
-        parameter_names_to_tags = meth.parameters.map do |name, _|
-          [name, meth.tags('param')
+        parameter_names_and_defaults_to_tags = meth.parameters.map do |name, default|
+          [[name, default], meth.tags('param')
             .find { |p| p.name&.gsub('*', '') == name.gsub('*', '') }]
         end.to_h
 
-        sig_params_list = parameter_names_to_tags.map do |name, tag|
-          name = name.gsub('*', '')
+        parameter_types = parameter_names_and_defaults_to_tags.map do |name_and_default, tag|
+          name = name_and_default.first
 
           if tag
-            "#{name}: #{TypeConverter.yard_to_sorbet(tag.types, meth, indent_level, @replace_errors_with_untyped)}"
+            TypeConverter.yard_to_sorbet(tag.types, meth, @replace_errors_with_untyped)
           elsif name.start_with? '&'
-            # Cut the ampersand from the block parameter name
-            name = name.gsub('&', '')
-
             # Find yieldparams and yieldreturn
             yieldparams = meth.tags('yieldparam')
             yieldreturn = meth.tag('yieldreturn')&.types
@@ -174,17 +110,17 @@ module Sord
 
             # Create strings
             params_string = yieldparams.map do |param|
-              "#{param.name.gsub('*', '')}: #{TypeConverter.yard_to_sorbet(param.types, meth, indent_level, @replace_errors_with_untyped)}" unless param.name.nil?
+              "#{param.name.gsub('*', '')}: #{TypeConverter.yard_to_sorbet(param.types, meth, @replace_errors_with_untyped)}" unless param.name.nil?
             end.join(', ')
-            return_string = TypeConverter.yard_to_sorbet(yieldreturn, meth, indent_level, @replace_errors_with_untyped)
+            return_string = TypeConverter.yard_to_sorbet(yieldreturn, meth, @replace_errors_with_untyped)
 
             # Create proc types, if possible
             if yieldparams.empty? && yieldreturn.nil?
-              "#{name}: T.untyped"
+              'T.untyped'
             elsif yieldreturn.nil?
-              "#{name}: T.proc#{params_string.empty? ? '' : ".params(#{params_string})"}.void"
+              "T.proc#{params_string.empty? ? '' : ".params(#{params_string})"}.void"
             else
-              "#{name}: T.proc#{params_string.empty? ? '' : ".params(#{params_string})"}.returns(#{return_string})"
+              "T.proc#{params_string.empty? ? '' : ".params(#{params_string})"}.returns(#{return_string})"
             end
           elsif meth.path.end_with? '='
             # Look for the matching getter method
@@ -192,88 +128,82 @@ module Sord
             getter = item.meths.find { |m| m.path == getter_path }
 
             unless getter
-              if parameter_names_to_tags.length == 1 \
+              if parameter_names_and_defaults_to_tags.length == 1 \
                 && meth.tags('param').length == 1 \
                 && meth.tag('param').types
   
-                Logging.infer("argument name in single @param inferred as #{parameter_names_to_tags.first.first.inspect}", meth, indent_level)
-                next "#{name}: #{TypeConverter.yard_to_sorbet(meth.tag('param').types, meth, indent_level, @replace_errors_with_untyped)}"
+                Logging.infer("argument name in single @param inferred as #{parameter_names_and_defaults_to_tags.first.first.first.inspect}", meth)
+                next TypeConverter.yard_to_sorbet(meth.tag('param').types, meth, @replace_errors_with_untyped)
               else  
-                Logging.omit("no YARD type given for #{name.inspect}, using T.untyped", meth, indent_level)
-                next "#{name}: T.untyped"
+                Logging.omit("no YARD type given for #{name.inspect}, using T.untyped", meth)
+                next 'T.untyped'
               end
             end
 
             inferred_type = TypeConverter.yard_to_sorbet(
-              getter.tags('return').flat_map(&:types), meth, indent_level, @replace_errors_with_untyped)
+              getter.tags('return').flat_map(&:types), meth, @replace_errors_with_untyped)
             
-            Logging.infer("inferred type of parameter #{name.inspect} as #{inferred_type} using getter's return type", meth, indent_level)
-            # Get rid of : on keyword arguments.
-            name = name.chop if name.end_with?(':')
-            "#{name}: #{inferred_type}"
+            Logging.infer("inferred type of parameter #{name.inspect} as #{inferred_type} using getter's return type", meth)
+            inferred_type
           else
             # Is this the only argument, and was a @param specified without an
             # argument name? If so, infer it
-            if parameter_names_to_tags.length == 1 \
+            if parameter_names_and_defaults_to_tags.length == 1 \
               && meth.tags('param').length == 1 \
               && meth.tag('param').types
 
-              Logging.infer("argument name in single @param inferred as #{parameter_names_to_tags.first.first.inspect}", meth, indent_level)
-              "#{name}: #{TypeConverter.yard_to_sorbet(meth.tag('param').types, meth, indent_level, @replace_errors_with_untyped)}"
+              Logging.infer("argument name in single @param inferred as #{parameter_names_and_defaults_to_tags.first.first.first.inspect}", meth)
+              TypeConverter.yard_to_sorbet(meth.tag('param').types, meth, @replace_errors_with_untyped)
             else
-              Logging.omit("no YARD type given for #{name.inspect}, using T.untyped", meth, indent_level)
-              # Get rid of : on keyword arguments.
-              name = name.chop if name.end_with?(':')
-              "#{name}: T.untyped"
+              Logging.omit("no YARD type given for #{name.inspect}, using T.untyped", meth)
+              'T.untyped'
             end
           end
         end
 
         return_tags = meth.tags('return')
         returns = if return_tags.length == 0
-          Logging.omit("no YARD return type given, using T.untyped", meth, indent_level)
-          "returns(T.untyped)"
+          Logging.omit("no YARD return type given, using T.untyped", meth)
+          'T.untyped'
         elsif return_tags.length == 1 && return_tags&.first&.types&.first&.downcase == "void"
-          "void"
+          nil
         else
-          "returns(#{TypeConverter.yard_to_sorbet(meth.tag('return').types, meth, indent_level, @replace_errors_with_untyped)})"
+          TypeConverter.yard_to_sorbet(meth.tag('return').types, meth, @replace_errors_with_untyped)
         end
 
-        prefix = meth.scope == :class ? 'self.' : ''
+        parlour_params = parameter_names_and_defaults_to_tags
+          .zip(parameter_types)
+          .map do |((name, default), _), type|
+            Parlour::RbiGenerator::Parameter.new(name.to_s, type: type, default: default)
+          end
 
-        add_signature(sig_params_list, returns, indent_level)
-
-        rbi_contents << "#{'  ' * (indent_level + 1)}def #{prefix}#{meth.name}(#{parameter_list}); end"
+        @current_object.create_method(meth.name.to_s, parlour_params, returns, class_method: meth.scope == :class)
       end
     end
 
     # Given a YARD NamespaceObject, add lines defining its mixins, methods
     # and children to the RBI file.
     # @param [YARD::CodeObjects::NamespaceObject] item
-    # @param [Integer] indent_level
     # @return [void]
-    def add_namespace(item, indent_level = 0)
+    def add_namespace(item)
       count_namespace
-      add_blank
 
-      if item.type == :class && item.superclass.to_s != "Object"
-        rbi_contents << "#{'  ' * indent_level}class #{item.name} < #{item.superclass.path}" 
-      else
-        rbi_contents << "#{'  ' * indent_level}#{item.type} #{item.name}"
-      end
+      superclass =
+        item.type == :class && item.superclass.to_s != "Object" \
+        ? item.superclass.name.to_s : nil
 
-      self.next_item_is_first_in_namespace = true
-      if add_mixins(item, indent_level) > 0
-        self.next_item_is_first_in_namespace = false
-      end
-      add_methods(item, indent_level)
+      parent = @current_object
+      @current_object = item.type == :class \
+        ? parent.create_class(item.name.to_s, superclass: superclass)
+        : parent.create_module(item.name.to_s)
+
+      add_mixins(item)
+      add_methods(item)
 
       item.children.select { |x| [:class, :module].include?(x.type) }
-        .each { |child| add_namespace(child, indent_level + 1) }
+        .each { |child| add_namespace(child) }
 
-      self.next_item_is_first_in_namespace = false
-
-      rbi_contents << "#{'  ' * indent_level}end"
+      @current_object = parent
     end
 
     # Generates the RBI file from the loading registry and returns its contents.
@@ -285,7 +215,8 @@ module Sord
         .select { |x| [:class, :module].include?(x.type) }
         .each { |child| add_namespace(child) }
 
-      rbi_contents.join("\n")
+      # Workaround for bug which will be fixed in Parlour at some point
+      "# typed: strong\n" + @parlour.rbi
     end
 
     # Generates the RBI file and writes it to the given file path, printing a

--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -250,10 +250,10 @@ module Sord
         else
           Logging.warn("The types which caused them have been replaced with SORD_ERROR_ constants.")
         end
-        Logging.warn("Please edit the file near the line numbers given to fix these errors.")
+        Logging.warn("Please edit the file to fix these errors.")
         Logging.warn("Alternatively, edit your YARD documentation so that your types are valid and re-run Sord.")
-        warnings.each do |(msg, item, line)|
-          puts "        #{"Line #{line} |".light_black} (#{item&.path&.bold}) #{msg}"
+        warnings.each do |(msg, item, _)|
+          puts "        (#{item&.path&.bold}) #{msg}"
         end
       end
     rescue

--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -41,7 +41,7 @@ module Sord
 
       # Hook the logger so that warnings are collected
       Logging.add_hook do |type, msg, item|
-        warnings << [msg, item, rbi_contents.length] \
+        warnings << [msg, item, rbi_contents.length] \ # TODO: is it possible to get line numbers here?
           if type == :warn
       end
     end

--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -94,11 +94,10 @@ module Sord
     # @param [YARD::CodeObjects::Base] item The CodeObject which the YARD type
     #   is associated with. This is used for logging and can be nil, but this
     #   will lead to less informative log messages.
-    # @param [Integer] indent_level 
     # @param [Boolean] replace_errors_with_untyped If true, T.untyped is used
     #   instead of SORD_ERROR_ constants for unknown types.
     # @return [String]
-    def self.yard_to_sorbet(yard, item = nil, indent_level = 0, replace_errors_with_untyped = false)
+    def self.yard_to_sorbet(yard, item = nil, replace_errors_with_untyped = false)
       case yard
       when nil # Type not specified
         "T.untyped"
@@ -111,7 +110,7 @@ module Sord
         # selection of any of the types
         types = yard
           .reject { |x| x == 'nil' }
-          .map { |x| yard_to_sorbet(x, item, indent_level, replace_errors_with_untyped) }
+          .map { |x| yard_to_sorbet(x, item, replace_errors_with_untyped) }
           .uniq
         result = types.length == 1 ? types.first : "T.any(#{types.join(', ')})"
         result = "T.nilable(#{result})" if yard.include?('nil')
@@ -119,7 +118,7 @@ module Sord
       when /^#{SIMPLE_TYPE_REGEX}$/
         # If this doesn't begin with an uppercase letter, warn
         if /^[_a-z]/ === yard
-          Logging.warn("#{yard} is probably not a type, but using anyway", item, indent_level)
+          Logging.warn("#{yard} is probably not a type, but using anyway", item)
         end
 
         # Check if whatever has been specified is actually resolvable; if not,
@@ -127,18 +126,18 @@ module Sord
         if item && !Resolver.resolvable?(yard, item)
           if Resolver.path_for(yard)
             new_path = Resolver.path_for(yard)
-            Logging.infer("#{yard} was resolved to #{new_path}", item, indent_level) \
+            Logging.infer("#{yard} was resolved to #{new_path}", item) \
               unless yard == new_path
             new_path
           else
-            Logging.warn("#{yard} wasn't able to be resolved to a constant in this project", item, indent_level)
+            Logging.warn("#{yard} wasn't able to be resolved to a constant in this project", item)
             yard
           end
         else
           yard
         end
       when DUCK_TYPE_REGEX
-        Logging.duck("#{yard} looks like a duck type, replacing with T.untyped", item, indent_level)
+        Logging.duck("#{yard} looks like a duck type, replacing with T.untyped", item)
         'T.untyped'
       when /^#{GENERIC_TYPE_REGEX}$/
         generic_type = $1
@@ -146,7 +145,7 @@ module Sord
 
         if SORBET_SUPPORTED_GENERIC_TYPES.include?(generic_type)
           parameters = split_type_parameters(type_parameters)
-            .map { |x| yard_to_sorbet(x, item, indent_level, replace_errors_with_untyped) }
+            .map { |x| yard_to_sorbet(x, item, replace_errors_with_untyped) }
           if SORBET_SINGLE_ARG_GENERIC_TYPES.include?(generic_type) && parameters.length > 1
             "T::#{generic_type}[T.any(#{parameters.join(', ')})]"
           elsif generic_type == 'Class' && parameters.length == 1
@@ -155,7 +154,7 @@ module Sord
             "T::#{generic_type}[#{parameters.join(', ')}]"
           end
         else
-          Logging.warn("unsupported generic type #{generic_type.inspect} in #{yard.inspect}", item, indent_level)
+          Logging.warn("unsupported generic type #{generic_type.inspect} in #{yard.inspect}", item)
           replace_errors_with_untyped ? "T.untyped" : "SORD_ERROR_#{generic_type.gsub(/[^0-9A-Za-z_]/i, '')}"
         end
       # Converts ordered lists like Array(Symbol, String) or (Symbol, String)
@@ -163,17 +162,17 @@ module Sord
       when ORDERED_LIST_REGEX
         type_parameters = $1
         parameters = split_type_parameters(type_parameters)
-          .map { |x| yard_to_sorbet(x, item, indent_level, replace_errors_with_untyped) }
+          .map { |x| yard_to_sorbet(x, item, replace_errors_with_untyped) }
         "[#{parameters.join(', ')}]"
       when SHORTHAND_HASH_SYNTAX
         type_parameters = $1
         parameters = split_type_parameters(type_parameters)
-          .map { |x| yard_to_sorbet(x, item, indent_level, replace_errors_with_untyped) }
+          .map { |x| yard_to_sorbet(x, item, replace_errors_with_untyped) }
         "T::Hash<#{parameters.join(', ')}>"
       when SHORTHAND_ARRAY_SYNTAX
         type_parameters = $1
         parameters = split_type_parameters(type_parameters)
-          .map { |x| yard_to_sorbet(x, item, indent_level, replace_errors_with_untyped) }
+          .map { |x| yard_to_sorbet(x, item, replace_errors_with_untyped) }
         parameters.one? \
           ? "T::Array<#{parameters.first}>"
           : "T::Array<T.any(#{parameters.join(', ')})>"
@@ -183,7 +182,7 @@ module Sord
         return from_yaml.class.to_s \
           if [Symbol, Float, Integer].include?(from_yaml.class)
 
-        Logging.warn("#{yard.inspect} does not appear to be a type", item, indent_level)
+        Logging.warn("#{yard.inspect} does not appear to be a type", item)
         replace_errors_with_untyped ? "T.untyped" : "SORD_ERROR_#{yard.gsub(/[^0-9A-Za-z_]/i, '')}"
       end
     end

--- a/rbi/sord.rbi
+++ b/rbi/sord.rbi
@@ -96,22 +96,12 @@ module Sord
   end
 
   class RbiGenerator
-    sig { returns(T::Array[String]) }
-    def rbi_contents(); end
-
     sig { returns(Integer) }
     def object_count(); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
     sig { returns(T::Array[[String, YARD::CodeObjects::Base, Integer]]) }
     def warnings(); end
-
-    sig { returns(T::Boolean) }
-    def next_item_is_first_in_namespace(); end
-
-    # sord infer - inferred type of parameter "value" as T::Boolean using getter's return type
-    sig { params(value: T::Boolean).returns(T::Boolean) }
-    def next_item_is_first_in_namespace=(value); end
 
     sig { params(options: Hash).void }
     def initialize(options); end
@@ -122,23 +112,17 @@ module Sord
     sig { void }
     def count_method(); end
 
-    sig { void }
-    def add_blank(); end
-
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig { params(item: YARD::CodeObjects::Base, indent_level: Integer).returns(Integer) }
-    def add_mixins(item, indent_level); end
-
-    sig { params(params: T::Array[String], returns: String, indent_level: Integer).void }
-    def add_signature(params, returns, indent_level); end
+    sig { params(item: YARD::CodeObjects::Base).returns(Integer) }
+    def add_mixins(item); end
 
     # sord warn - YARD::CodeObjects::NamespaceObject wasn't able to be resolved to a constant in this project
-    sig { params(item: YARD::CodeObjects::NamespaceObject, indent_level: Integer).void }
-    def add_methods(item, indent_level); end
+    sig { params(item: YARD::CodeObjects::NamespaceObject).void }
+    def add_methods(item); end
 
     # sord warn - YARD::CodeObjects::NamespaceObject wasn't able to be resolved to a constant in this project
-    sig { params(item: YARD::CodeObjects::NamespaceObject, indent_level: Integer).void }
-    def add_namespace(item, indent_level = 0); end
+    sig { params(item: YARD::CodeObjects::NamespaceObject).void }
+    def add_namespace(item); end
 
     sig { returns(String) }
     def generate(); end
@@ -152,14 +136,7 @@ module Sord
     def self.split_type_parameters(params); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig do
-      params(
-        yard: T.any(T::Boolean, Array, String),
-        item: YARD::CodeObjects::Base,
-        indent_level: Integer,
-        replace_errors_with_untyped: T::Boolean
-      ).returns(String)
-    end
-    def self.yard_to_sorbet(yard, item = nil, indent_level = 0, replace_errors_with_untyped = false); end
+    sig { params(yard: T.any(T::Boolean, Array, String), item: YARD::CodeObjects::Base, replace_errors_with_untyped: T::Boolean).returns(String) }
+    def self.yard_to_sorbet(yard, item = nil, replace_errors_with_untyped = false); end
   end
 end

--- a/rbi/sord.rbi
+++ b/rbi/sord.rbi
@@ -2,10 +2,10 @@
 module Sord
   module Logging
     sig { returns(T::Array[Proc]) }
-    def self.hooks(); end
+    def self.hooks; end
 
     sig { returns(T::Boolean) }
-    def self.silent?(); end
+    def self.silent?; end
 
     sig { params(value: T::Boolean).void }
     def self.silent=(value); end
@@ -14,7 +14,7 @@ module Sord
     def self.enabled_types=(value); end
 
     sig { returns(T::Array[Symbol]) }
-    def self.enabled_types(); end
+    def self.enabled_types; end
 
     sig { params(value: T::Array[Symbol]).void }
     def self.valid_types?(value); end
@@ -26,7 +26,7 @@ module Sord
         header: String,
         msg: String,
         item: YARD::CodeObjects::Base,
-        indent_level: Integer
+        indent_level: Integer,
       ).void
     end
     def self.generic(kind, header, msg, item, indent_level = 0); end
@@ -65,7 +65,7 @@ module Sord
         kind: Symbol,
         msg: String,
         item: YARD::CodeObjects::Base,
-        indent_level: Integer
+        indent_level: Integer,
       ).void
     end
     def self.invoke_hooks(kind, msg, item, indent_level = 0); end
@@ -77,10 +77,10 @@ module Sord
 
   module Resolver
     sig { void }
-    def self.prepare(); end
+    def self.prepare; end
 
     sig { void }
-    def self.clear(); end
+    def self.clear; end
 
     sig { params(name: String).returns(T::Array[String]) }
     def self.paths_for(name); end
@@ -89,7 +89,7 @@ module Sord
     def self.path_for(name); end
 
     sig { returns(T::Array[String]) }
-    def self.builtin_classes(); end
+    def self.builtin_classes; end
 
     sig { params(name: String, item: Object).returns(T::Boolean) }
     def self.resolvable?(name, item); end
@@ -97,20 +97,20 @@ module Sord
 
   class RbiGenerator
     sig { returns(Integer) }
-    def object_count(); end
+    def object_count; end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
     sig { returns(T::Array[[String, YARD::CodeObjects::Base, Integer]]) }
-    def warnings(); end
+    def warnings; end
 
     sig { params(options: Hash).void }
     def initialize(options); end
 
     sig { void }
-    def count_namespace(); end
+    def count_namespace; end
 
     sig { void }
-    def count_method(); end
+    def count_method; end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
     sig { params(item: YARD::CodeObjects::Base).returns(Integer) }
@@ -125,7 +125,7 @@ module Sord
     def add_namespace(item); end
 
     sig { returns(String) }
-    def generate(); end
+    def generate; end
 
     sig { params(filename: T.nilable(String)).void }
     def run(filename); end
@@ -136,20 +136,14 @@ module Sord
     def self.split_type_parameters(params); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-<<<<<<< HEAD
-    sig { params(yard: T.any(T::Boolean, Array, String), item: YARD::CodeObjects::Base, replace_errors_with_untyped: T::Boolean).returns(String) }
-    def self.yard_to_sorbet(yard, item = nil, replace_errors_with_untyped = false); end
-=======
     sig do
       params(
         yard: T.any(T::Boolean, Array, String),
         item: YARD::CodeObjects::Base,
-        indent_level: Integer,
         replace_errors_with_untyped: T::Boolean,
-        replace_unresolved_with_untyped: T::Boolean
+        replace_unresolved_with_untyped: T::Boolean,
       ).returns(String)
     end
-    def self.yard_to_sorbet(yard, item = nil, indent_level = 0, replace_errors_with_untyped = false, replace_unresolved_with_untyped = false); end
->>>>>>> master
+    def self.yard_to_sorbet(yard, item = nil, replace_errors_with_untyped = false, replace_unresolved_with_untyped = false); end
   end
 end

--- a/sord.gemspec
+++ b/sord.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sorbet-runtime'
   spec.add_dependency 'colorize'
   spec.add_dependency 'commander', '~> 4.4'
-  spec.add_dependency 'parlour', '~> 0.2.2'
+  spec.add_dependency 'parlour', '~> 0.3.1'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/sord.gemspec
+++ b/sord.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sorbet-runtime'
   spec.add_dependency 'colorize'
   spec.add_dependency 'commander', '~> 4.4'
+  spec.add_dependency 'parlour', '~> 0.2.1'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/sord.gemspec
+++ b/sord.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sorbet-runtime'
   spec.add_dependency 'colorize'
   spec.add_dependency 'commander', '~> 4.4'
-  spec.add_dependency 'parlour', '~> 0.2.1'
+  spec.add_dependency 'parlour', '~> 0.2.2'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -79,7 +79,7 @@ describe Sord::RbiGenerator do
       module A
         class B
           sig { returns(Integer) }
-          def foo(); end
+          def foo; end
         end
 
         module C
@@ -115,7 +115,7 @@ describe Sord::RbiGenerator do
         class B
           # sord omit - no YARD return type given, using T.untyped
           sig { returns(T.untyped) }
-          def foo(); end
+          def foo; end
         end
 
         module C
@@ -137,8 +137,8 @@ describe Sord::RbiGenerator do
       class C; end
 
       class D < A
-        extend B
-        include C
+        include B
+        extend C
         def x; end
       end
     RUBY
@@ -155,12 +155,12 @@ describe Sord::RbiGenerator do
       end
 
       class D < A
-        extend B
-        include C
+        include B
+        extend C
 
         # sord omit - no YARD return type given, using T.untyped
         sig { returns(T.untyped) }
-        def x(); end
+        def x; end
       end
     RUBY
   end
@@ -305,7 +305,7 @@ describe Sord::RbiGenerator do
             a: Integer,
             b: String,
             c: Float,
-            d: Object
+            d: Object,
           ).void
         end
         def foo(a, b, c, d); end
@@ -327,7 +327,7 @@ describe Sord::RbiGenerator do
       # typed: strong
       module A
         sig { returns(Integer) }
-        def x(); end
+        def x; end
 
         # sord infer - inferred type of parameter "value" as Integer using getter's return type
         # sord omit - no YARD return type given, using T.untyped

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -306,7 +306,7 @@ describe Sord::RbiGenerator do
             a: Integer,
             b: String,
             c: Float,
-            d: Object,
+            d: Object
           ).void
         end
         def foo(a, b, c, d); end

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -182,7 +182,7 @@ describe Sord::TypeConverter do
         end
 
         it 'T.untyped rather than SORD_ERROR if option is set' do
-          expect(subject.yard_to_sorbet('Hash{String, Symbol', nil, 0, true)).to eq 'T.untyped'
+          expect(subject.yard_to_sorbet('Hash{String, Symbol', nil, true)).to eq 'T.untyped'
         end
       end
     end


### PR DESCRIPTION
This currently supports everything except warning line numbers, which have been temporarily removed from output. (I'm not sure how they could be implemented in Parlour given the way it's built, and I'm also not sure how necessary they are since the definition associated with each warning is also shown.)

@connorshea - if you'd be able to give this a quick code review at some point, that'd be super useful! Thanks