### PR TITLE
Don't generate signatures for inherited methods.

### DIFF
--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -80,7 +80,7 @@ module Sord
     # @param [YARD::CodeObjects::NamespaceObject] item
     # @return [void]
     def add_methods(item)
-      item.meths.each do |meth|
+      item.meths(inherited: false).each do |meth|
         count_method
 
         # If the method is an alias, skip it so we don't define it as a

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -397,4 +397,31 @@ describe Sord::RbiGenerator do
       end
     RUBY
   end
+
+  it 'does not include inherited methods in its output' do
+    YARD.parse_string(<<-RUBY)
+      class A
+        # @return [void]
+        def x; end
+      end
+
+      class B < A
+        # @return [void]
+        def y; end
+      end
+    RUBY
+
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      class A
+        sig { void }
+        def x; end
+      end
+
+      class B < A
+        sig { void }
+        def y; end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Sorbet can figure these out on its own.

Fixes #88.