### PR TITLE
Improve constant generation.

### DIFF
--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -69,10 +69,10 @@ module Sord
     # @return [Integer]
     def add_mixins(item)
       item.instance_mixins.reverse_each do |i|
-        @current_object.add_include(i.name.to_s)
+        @current_object.add_include(i.path.to_s)
       end
       item.class_mixins.reverse_each do |e|
-        @current_object.add_extend(e.name.to_s)
+        @current_object.add_extend(e.path.to_s)
       end
 
       item.instance_mixins.length + item.class_mixins.length


### PR DESCRIPTION
This is just what you suggested in #87, I can't take credit for it :P

Before

```
Errors
addressable: 2
    bundler: 54
  discordrb: 5
     gitlab: 8
       haml: 2
        oga: 9
      rouge: 1
 rspec-core: 45
       yard: 77
   zeitwerk: 6
      Total: 209
```

After

```
Errors
addressable: 2
    bundler: 48
  discordrb: 5
     gitlab: 4
       haml: 2
        oga: 9
      rouge: 1
 rspec-core: 43
       yard: 55
   zeitwerk: 6
      Total: 175
```