### PR TITLE
Don't generate an invalid hash when given an invalid YARD type.

### DIFF
--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -163,6 +163,12 @@ module Sord
             "T::#{generic_type}[T.any(#{parameters.join(', ')})]"
           elsif generic_type == 'Class' && parameters.length == 1
             "T.class_of(#{parameters.first})"
+          elsif generic_type == 'Hash'
+            if parameters.length == 2
+              "T::Hash[#{parameters.join(', ')}]"
+            else
+              handle_sord_error(parameters.join, "Invalid hash, must have exactly two types: #{yard.inspect}.", item, replace_errors_with_untyped)
+            end
           else
             "T::#{generic_type}[#{parameters.join(', ')}]"
           end
@@ -186,10 +192,10 @@ module Sord
         parameters = split_type_parameters(type_parameters)
           .map { |x| yard_to_sorbet(x, item, replace_errors_with_untyped, replace_unresolved_with_untyped) }
         # Return a warning about an invalid hash when it has more or less than two elements.
-        if parameters.length != 2
-          return handle_sord_error(parameters.join, "Invalid hash, must have exactly two types: #{parameters}.", item, replace_errors_with_untyped)
+        if parameters.length == 2
+          "T::Hash[#{parameters.join(', ')}]"
         else
-          return "T::Hash[#{parameters.join(', ')}]"
+          handle_sord_error(parameters.join, "Invalid hash, must have exactly two types: #{yard.inspect}.", item, replace_errors_with_untyped)
         end
       when SHORTHAND_ARRAY_SYNTAX
         type_parameters = $1

--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -204,7 +204,7 @@ module Sord
         return from_yaml.class.to_s \
           if [Symbol, Float, Integer].include?(from_yaml.class)
 
-        return handle_sord_error(yard, "#{yard.inspect} does not appear to be a type", item, replace_errors_with_untyped)
+        return handle_sord_error(yard.to_s, "#{yard.inspect} does not appear to be a type", item, replace_errors_with_untyped)
       end
     end
 
@@ -216,7 +216,7 @@ module Sord
     # @param [Boolean] replace_errors_with_untyped
     # @return [String]
     def self.handle_sord_error(name, log_warning, item, replace_errors_with_untyped)
-      Logging.warn(logging_warning, item)
+      Logging.warn(log_warning, item)
       return replace_errors_with_untyped ? "T.untyped" : "SORD_ERROR_#{name.gsub(/[^0-9A-Za-z_]/i, '')}"
     end
   end

--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -185,9 +185,9 @@ module Sord
         type_parameters = $1
         parameters = split_type_parameters(type_parameters)
           .map { |x| yard_to_sorbet(x, item, replace_errors_with_untyped, replace_unresolved_with_untyped) }
-        # Return an invalid 
-        if parameters.length > 2
-          return handle_sord_error(parameters.join, "Invalid hash with more than two types: #{parameters}.", item, replace_errors_with_untyped)
+        # Return a warning about an invalid hash when it has more or less than two elements.
+        if parameters.length != 2
+          return handle_sord_error(parameters.join, "Invalid hash, must have exactly two types: #{parameters}.", item, replace_errors_with_untyped)
         else
           return "T::Hash[#{parameters.join(', ')}]"
         end

--- a/rbi/sord.rbi
+++ b/rbi/sord.rbi
@@ -31,31 +31,31 @@ module Sord
     def self.generic(kind, header, msg, item); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig { params(msg: String, item: YARD::CodeObjects::Base).void }
+    sig { params(msg: String, item: T.nilable(YARD::CodeObjects::Base)).void }
     def self.warn(msg, item = nil); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig { params(msg: String, item: YARD::CodeObjects::Base).void }
+    sig { params(msg: String, item: T.nilable(YARD::CodeObjects::Base)).void }
     def self.info(msg, item = nil); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig { params(msg: String, item: YARD::CodeObjects::Base).void }
+    sig { params(msg: String, item: T.nilable(YARD::CodeObjects::Base)).void }
     def self.duck(msg, item = nil); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig { params(msg: String, item: YARD::CodeObjects::Base).void }
+    sig { params(msg: String, item: T.nilable(YARD::CodeObjects::Base)).void }
     def self.error(msg, item = nil); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig { params(msg: String, item: YARD::CodeObjects::Base).void }
+    sig { params(msg: String, item: T.nilable(YARD::CodeObjects::Base)).void }
     def self.infer(msg, item = nil); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig { params(msg: String, item: YARD::CodeObjects::Base).void }
+    sig { params(msg: String, item: T.nilable(YARD::CodeObjects::Base)).void }
     def self.omit(msg, item = nil); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig { params(msg: String, item: YARD::CodeObjects::Base).void }
+    sig { params(msg: String, item: T.nilable(YARD::CodeObjects::Base)).void }
     def self.done(msg, item = nil); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
@@ -157,11 +157,22 @@ module Sord
     sig do
       params(
         yard: T.any(T::Boolean, T::Array[T.untyped], String),
-        item: YARD::CodeObjects::Base,
+        item: T.nilable(YARD::CodeObjects::Base),
         replace_errors_with_untyped: T::Boolean,
         replace_unresolved_with_untyped: T::Boolean
       ).returns(String)
     end
     def self.yard_to_sorbet(yard, item = nil, replace_errors_with_untyped = false, replace_unresolved_with_untyped = false); end
+
+    # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
+    sig do
+      params(
+        name: String,
+        log_warning: String,
+        item: YARD::CodeObjects::Base,
+        replace_errors_with_untyped: T::Boolean
+      ).returns(String)
+    end
+    def self.handle_sord_error(name, log_warning, item, replace_errors_with_untyped); end
   end
 end

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -219,6 +219,10 @@ describe Sord::TypeConverter do
         it 'SORD_ERROR for a hash with too many parameters' do
           expect(subject.yard_to_sorbet('{Integer, Integer, Integer}')).to eq 'SORD_ERROR_IntegerIntegerInteger'
         end
+
+        it 'SORD_ERROR for a hash with too few parameters' do
+          expect(subject.yard_to_sorbet('{Integer}')).to eq 'SORD_ERROR_Integer'
+        end
       end
     end
   end

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -146,6 +146,7 @@ describe Sord::TypeConverter do
         it 'handles shorthand Hash syntax' do
           expect(subject.yard_to_sorbet('{String => Symbol}')).to eq 'T::Hash[String, Symbol]'
           expect(subject.yard_to_sorbet('{{String => Integer} => {Symbol => Float}}')).to eq 'T::Hash[T::Hash[String, Integer], T::Hash[Symbol, Float]]'
+          expect(subject.yard_to_sorbet('{{String, Integer}, {Symbol, Float}}')).to eq 'T::Hash[T::Hash[String, Integer], T::Hash[Symbol, Float]]'
         end
 
         it 'handles shorthand Array syntax' do
@@ -213,6 +214,10 @@ describe Sord::TypeConverter do
 
         it 'T.untyped rather than unresolved constant if option is set' do
           expect(subject.yard_to_sorbet('TestConstantThatDoesNotExist', YARD::CodeObjects::NamespaceObject.new(:root, :Foo), false, true)).to eq 'T.untyped'
+        end
+
+        it 'SORD_ERROR for a hash with too many parameters' do
+          expect(subject.yard_to_sorbet('{Integer, Integer, Integer}')).to eq 'SORD_ERROR_IntegerIntegerInteger'
         end
       end
     end

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -223,6 +223,10 @@ describe Sord::TypeConverter do
         it 'SORD_ERROR for a hash with too few parameters' do
           expect(subject.yard_to_sorbet('{Integer}')).to eq 'SORD_ERROR_Integer'
         end
+
+        it 'SORD_ERROR for a hash with too few parameters' do
+          expect(subject.yard_to_sorbet('Hash<Array>')).to eq 'SORD_ERROR_TArrayTuntyped'
+        end
       end
     end
   end


### PR DESCRIPTION
Also update sord.rbi.

This splits the SORD_ERROR handling into a separate method since it was used in a few different places with pretty much the same code.