### PR TITLE
Add support for constants

### DIFF
--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -78,6 +78,20 @@ module Sord
       item.instance_mixins.length + item.class_mixins.length
     end
 
+    # Given a YARD NamespaceObject, add lines defining constants.
+    # @param [YARD::CodeObjects::NamespaceObject] item
+    # @return [void]
+    def add_constants(item)
+      item.constants.each do |constant|
+        # Take a constant (like "A::B::CONSTANT"), and remove the name of the current
+        # class/module (like "A::B") from it to get the correct constant name.
+        constant_name = constant.to_s.sub("#{item.name.to_s}::", "")
+        
+        # Add the constant to the current object being generated.
+        @current_object.add_constant(constant_name, "T.let(#{constant.value}, T.untyped)")
+      end
+    end
+
     # Given a YARD NamespaceObject, add lines defining its methods and their
     # signatures to the current RBI file.
     # @param [YARD::CodeObjects::NamespaceObject] item
@@ -217,6 +231,7 @@ module Sord
 
       add_mixins(item)
       add_methods(item)
+      add_constants(item)
 
       item.children.select { |x| [:class, :module].include?(x.type) }
         .each { |child| add_namespace(child) }

--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -83,9 +83,9 @@ module Sord
     # @return [void]
     def add_constants(item)
       item.constants.each do |constant|
-        # Take a constant (like "A::B::CONSTANT"), and remove the name of the current
-        # class/module (like "A::B") from it to get the correct constant name.
-        constant_name = constant.to_s.sub("#{item.name.to_s}::", "")
+        # Take a constant (like "A::B::CONSTANT"), split it on each '::', and
+        # set the constant name to the last string in the array.
+        constant_name = constant.to_s.split('::').last
         
         # Add the constant to the current object being generated.
         @current_object.add_constant(constant_name, "T.let(#{constant.value}, T.untyped)")

--- a/rbi/sord.rbi
+++ b/rbi/sord.rbi
@@ -1,6 +1,10 @@
 # typed: strong
 module Sord
+  VERSION = T.let('0.8.0', T.untyped)
+
   module Logging
+    AVAILABLE_TYPES = T.let([:warn, :info, :duck, :error, :infer, :omit, :done].freeze, T.untyped)
+
     sig { returns(T::Array[Proc]) }
     def self.hooks; end
 
@@ -31,31 +35,31 @@ module Sord
     def self.generic(kind, header, msg, item); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig { params(msg: String, item: YARD::CodeObjects::Base).void }
+    sig { params(msg: String, item: T.nilable(YARD::CodeObjects::Base)).void }
     def self.warn(msg, item = nil); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig { params(msg: String, item: YARD::CodeObjects::Base).void }
+    sig { params(msg: String, item: T.nilable(YARD::CodeObjects::Base)).void }
     def self.info(msg, item = nil); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig { params(msg: String, item: YARD::CodeObjects::Base).void }
+    sig { params(msg: String, item: T.nilable(YARD::CodeObjects::Base)).void }
     def self.duck(msg, item = nil); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig { params(msg: String, item: YARD::CodeObjects::Base).void }
+    sig { params(msg: String, item: T.nilable(YARD::CodeObjects::Base)).void }
     def self.error(msg, item = nil); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig { params(msg: String, item: YARD::CodeObjects::Base).void }
+    sig { params(msg: String, item: T.nilable(YARD::CodeObjects::Base)).void }
     def self.infer(msg, item = nil); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig { params(msg: String, item: YARD::CodeObjects::Base).void }
+    sig { params(msg: String, item: T.nilable(YARD::CodeObjects::Base)).void }
     def self.omit(msg, item = nil); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
-    sig { params(msg: String, item: YARD::CodeObjects::Base).void }
+    sig { params(msg: String, item: T.nilable(YARD::CodeObjects::Base)).void }
     def self.done(msg, item = nil); end
 
     # sord warn - YARD::CodeObjects::Base wasn't able to be resolved to a constant in this project
@@ -110,6 +114,10 @@ module Sord
 
     # sord warn - YARD::CodeObjects::NamespaceObject wasn't able to be resolved to a constant in this project
     sig { params(item: YARD::CodeObjects::NamespaceObject).void }
+    def add_constants(item); end
+
+    # sord warn - YARD::CodeObjects::NamespaceObject wasn't able to be resolved to a constant in this project
+    sig { params(item: YARD::CodeObjects::NamespaceObject).void }
     def add_methods(item); end
 
     # sord warn - YARD::CodeObjects::NamespaceObject wasn't able to be resolved to a constant in this project
@@ -150,6 +158,15 @@ module Sord
   end
 
   module TypeConverter
+    SIMPLE_TYPE_REGEX = T.let(/(?:\:\:)?[a-zA-Z_][\w]*(?:\:\:[a-zA-Z_][\w]*)*/, T.untyped)
+    GENERIC_TYPE_REGEX = T.let(/(#{SIMPLE_TYPE_REGEX})\s*[<{]\s*(.*)\s*[>}]/, T.untyped)
+    DUCK_TYPE_REGEX = T.let(/^\#[a-zA-Z_][\w]*(?:[a-zA-Z_][\w=]*)*(?:( ?\& ?\#)*[a-zA-Z_][\w=]*)*$/, T.untyped)
+    ORDERED_LIST_REGEX = T.let(/^(?:Array|)\((.*)\s*\)$/, T.untyped)
+    SHORTHAND_HASH_SYNTAX = T.let(/^{\s*(.*)\s*}$/, T.untyped)
+    SHORTHAND_ARRAY_SYNTAX = T.let(/^<\s*(.*)\s*>$/, T.untyped)
+    SORBET_SUPPORTED_GENERIC_TYPES = T.let(%w{Array Set Enumerable Enumerator Range Hash Class}, T.untyped)
+    SORBET_SINGLE_ARG_GENERIC_TYPES = T.let(%w{Array Set Enumerable Enumerator Range}, T.untyped)
+
     sig { params(params: String).returns(T::Array[String]) }
     def self.split_type_parameters(params); end
 
@@ -157,7 +174,7 @@ module Sord
     sig do
       params(
         yard: T.any(T::Boolean, T::Array[T.untyped], String),
-        item: YARD::CodeObjects::Base,
+        item: T.nilable(YARD::CodeObjects::Base),
         replace_errors_with_untyped: T::Boolean,
         replace_unresolved_with_untyped: T::Boolean
       ).returns(String)

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -517,4 +517,43 @@ describe Sord::RbiGenerator do
       end
     RUBY
   end
+
+  it 'handles constants' do
+    YARD.parse_string(<<-RUBY)
+      class A
+        EXAMPLE_CONSTANT = 'Foo'
+      end
+    RUBY
+
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      class A
+        EXAMPLE_CONSTANT = T.let('Foo', T.untyped)
+      end
+    RUBY
+  end
+
+
+  it 'does not generate constants from included classes' do
+    YARD.parse_string(<<-RUBY)
+      class A
+        EXAMPLE_CONSTANT = 'Foo'
+      end
+
+      class B
+        include A
+      end
+    RUBY
+
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      class A
+        EXAMPLE_CONSTANT = T.let('Foo', T.untyped)
+      end
+
+      class B
+        include A
+      end
+    RUBY
+  end
 end

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -556,4 +556,24 @@ describe Sord::RbiGenerator do
       end
     RUBY
   end
+
+
+  it 'correctly generates constants in nested classes' do
+    YARD.parse_string(<<-RUBY)
+      class A
+        class B
+          EXAMPLE_CONSTANT = 'Foo'
+        end
+      end
+    RUBY
+
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      class A
+        class B
+          EXAMPLE_CONSTANT = T.let('Foo', T.untyped)
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This implements generating constants as part of Sord.

See the Sorbet documentation on annotating constants: https://sorbet.org/docs/type-annotations#annotating-constants

It currently generates all of them as `T.untyped`, I'm not sure how common it is to include the type of a constant in YARD docs, or if there's a good way to determine the type of a constant's value? 

It uses a bit of a hack because of a quirk with how Ruby's constant namespacing works, which I'm not entirely sure I've handled correctly.

Essentially, Ruby like this results in YARD returning `A::EXAMPLE_CONSTANT` as the name of the constant here

```ruby
class A
  class B
    EXAMPLE_CONSTANT = 'Foo'
  end
end
```

I'm not sure if this is a bug in YARD or if this is how Ruby constant namespacing actually works, I admittedly haven't used constants in Ruby very often.

My solution to this originally was to just strip the parent classes/modules namespace from the start of the constant name, but that assumed the constant name would be something more like `A::B::EXAMPLE_CONSTANT`. Since this turned out to be an incorrect assumption, I changed it to split the constant name on `::` and just use the last string in the resulting array.

I'm guessing my solution will break on some edge cases, e.g. I'm not sure how this should be handled, or if it's even valid:

```ruby
class A
end

A::EXAMPLE_CONSTANT = 'Foo'
```