### PR TITLE
Return fully-qualified superclasses

### DIFF
--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -206,9 +206,8 @@ module Sord
     def add_namespace(item)
       count_namespace
 
-      superclass =
-        item.type == :class && item.superclass.to_s != "Object" \
-        ? item.superclass.name.to_s : nil
+      superclass = nil
+      superclass = item.superclass.path.to_s if item.type == :class && item.superclass.to_s != "Object"
 
       parent = @current_object
       @current_object = item.type == :class \

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -517,4 +517,33 @@ describe Sord::RbiGenerator do
       end
     RUBY
   end
+
+  it 'returns fully qualified superclasses' do
+    YARD.parse_string(<<-RUBY)
+      class Alphabet
+      end
+  
+      class Letters < Alphabet
+      end
+  
+      class A < Alphabet::Letters
+        # @return [void]
+        def x; end
+      end
+    RUBY
+  
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      class Alphabet
+      end
+      
+      class Letters < Alphabet
+      end
+      
+      class A < Alphabet::Letters
+        sig { void }
+        def x; end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This fixes a lot of errors with classes inheriting from the incorrect class names.

Fixes part of #87.

This technically won't match the original code perfectly in all situations. I'm not sure whether we care about that.