### PR TITLE
Include comments in generated RBIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ where the maintainer is unwilling to ship type signatures with the gem itself.
 
 Sord also takes some flags to alter the generated `.rbi` file:
 
-  - `--no-comments`: Generates the `.rbi` file without any comments about
-    warnings/inferences/errors.
+  - `--no-sord-comments`: Generates the `.rbi` file without any Sord comments 
+    about warnings/inferences/errors. (The original file's comments will still
+    be included.)
   - `--no-regenerate`: By default, Sord will regenerate a repository's YARD
     docs for you. This option skips regenerating the YARD docs.
   - `--break-params`: Determines how many parameters are necessary before

--- a/README.md
+++ b/README.md
@@ -116,9 +116,13 @@ The `test.rbi` file then contains a complete RBI file for `test.rb`:
 # typed: strong
 module Example
   class Person
+    # @param [String] name
+    # @param [Integer] age
+    # @return [Example::Person]
     sig { params(name: String, age: Integer).returns(Example::Person) }
     def initialize(name, age); end
 
+    # @return [String] name
     sig { returns(String) }
     def name(); end
 
@@ -126,6 +130,7 @@ module Example
     sig { params(value: String).returns(String) }
     def name=(value); end
 
+    # @return [Integer] age
     sig { returns(Integer) }
     def age(); end
 
@@ -133,6 +138,9 @@ module Example
     sig { params(value: Integer).returns(Integer) }
     def age=(value); end
 
+    # @param [Array<String>] possible_names
+    # @param [Array<Integer>] possible_ages
+    # @return [Example::Person]
     sig { params(possible_names: T::Array[String], possible_ages: T::Array[Integer]).returns(Example::Person) }
     def self.construct_randomly(possible_names, possible_ages); end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -45,7 +45,7 @@ namespace :examples do
         # Generate sri
         puts "Generating rbi for #{name}..."
         if args[:clean]
-          system("bundle exec sord ../#{name}.rbi --no-comments --replace-errors-with-untyped --replace-unresolved-with-untyped")
+          system("bundle exec sord ../#{name}.rbi --no-sord-comments --replace-errors-with-untyped --replace-unresolved-with-untyped")
         else
           system("bundle exec sord ../#{name}.rbi")
         end
@@ -70,7 +70,7 @@ namespace :examples do
       puts "Regenerating rbi file for #{name}..."
       Bundler.with_clean_env do
         if args[:clean]
-          system("bundle exec sord ../#{name}.rbi --no-regenerate --no-comments --replace-errors-with-untyped --replace-unresolved-with-untyped")
+          system("bundle exec sord ../#{name}.rbi --no-regenerate --no-sord-comments --replace-errors-with-untyped --replace-unresolved-with-untyped")
         else
           system("bundle exec sord ../#{name}.rbi --no-regenerate")
         end

--- a/exe/sord
+++ b/exe/sord
@@ -11,7 +11,7 @@ default_command :gen
 command :gen do |c|
   c.syntax = 'sord gen <output-file> [options]'
   c.description = 'Generates an RBI file from this directory\'s YARD docs'
-  c.option '--[no-]comments', 'Controls informational/warning comments in the RBI file'
+  c.option '--[no-]sord-comments', 'Controls informational/warning comments in the RBI file'
   c.option '--[no-]regenerate', 'Controls whether YARD is executed before Sord runs'
   c.option '--break-params INTEGER', Integer, 'Break params onto their own lines if there are this many'
   c.option '--replace-errors-with-untyped', 'Uses T.untyped rather than SORD_ERROR_ constants'
@@ -21,7 +21,7 @@ command :gen do |c|
 
   c.action do |args, options|
     options.default(
-      comments: true,
+      sord_comments: true,
       regenerate: true,
       break_params: 4,
       replace_errors_with_untyped: false,

--- a/lib/sord/parlour_plugin.rb
+++ b/lib/sord/parlour_plugin.rb
@@ -10,7 +10,8 @@ module Sord
       @parlour = nil
       @options = options
 
-      options[:comments] = true if options[:comments].nil?
+      options[:sord_comments] = true if options[:sord_comments].nil?
+      p options[:sord_comments]
       options[:regenerate] = true if options[:regenerate].nil?
       options[:replace_errors_with_untyped] ||= false
       options[:replace_unresolved_with_untyped] ||= false

--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -158,8 +158,13 @@ module Sord
               end
             end
 
+            return_types = getter.tags('return').flat_map(&:types)
+            unless return_types.any?
+              Logging.omit("no YARD type given for #{name.inspect}, using T.untyped", meth)
+              next 'T.untyped'
+            end
             inferred_type = TypeConverter.yard_to_sorbet(
-              getter.tags('return').flat_map(&:types), meth, @replace_errors_with_untyped, @replace_unresolved_with_untyped)
+              return_types, meth, @replace_errors_with_untyped, @replace_unresolved_with_untyped)
             
             Logging.infer("inferred type of parameter #{name.inspect} as #{inferred_type} using getter's return type", meth)
             inferred_type

--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -42,7 +42,7 @@ module Sord
       # Hook the logger so that messages are added as comments to the RBI file
       Logging.add_hook do |type, msg, item|
         @current_object.add_comment_to_next_child("sord #{type} - #{msg}")
-      end if options[:comments]
+      end if options[:sord_comments]
 
       # Hook the logger so that warnings are collected
       Logging.add_hook do |type, msg, item|

--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -88,7 +88,9 @@ module Sord
         constant_name = constant.to_s.split('::').last
         
         # Add the constant to the current object being generated.
-        @current_object.create_constant(constant_name, value: "T.let(#{constant.value}, T.untyped)")
+        @current_object.create_constant(constant_name, value: "T.let(#{constant.value}, T.untyped)") do |c|
+          c.add_comments(constant.docstring.all.split("\n"))
+        end
       end
     end
 
@@ -214,7 +216,9 @@ module Sord
           parameters: parlour_params,
           returns: returns,
           class_method: meth.scope == :class
-        )
+        ) do |m|
+          m.add_comments(meth.docstring.all.split("\n"))
+        end
       end
     end
 
@@ -232,6 +236,7 @@ module Sord
       @current_object = item.type == :class \
         ? parent.create_class(item.name.to_s, superclass: superclass)
         : parent.create_module(item.name.to_s)
+      @current_object.add_comments(item.docstring.all.split("\n"))
 
       add_mixins(item)
       add_methods(item)

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -339,6 +339,30 @@ describe Sord::RbiGenerator do
     RUBY
   end
 
+  it 'does not attempt inference when there is no setter type' do
+    YARD.parse_string(<<-RUBY)
+      module A
+        def x; end
+
+        def x=(value); end
+      end
+    RUBY
+
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      module A
+        # sord omit - no YARD return type given, using T.untyped
+        sig { returns(T.untyped) }
+        def x; end
+
+        # sord omit - no YARD type given for "value", using T.untyped
+        # sord omit - no YARD return type given, using T.untyped
+        sig { params(value: T.untyped).returns(T.untyped) }
+        def x=(value); end
+      end
+    RUBY
+  end
+
   it 'infers one missing argument name in standard methods' do
     YARD.parse_string(<<-RUBY)
       module A

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -80,12 +80,15 @@ describe Sord::RbiGenerator do
       # typed: strong
       module A
         class B
+          # @return [Integer]
           sig { returns(Integer) }
           def foo; end
         end
 
         module C
           class D
+            # @param [String] x
+            # @return [void]
             sig { params(x: String).void }
             def bar(x); end
           end
@@ -243,6 +246,11 @@ describe Sord::RbiGenerator do
     expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       module A
+        # @param [String] x
+        # @return [Boolean]
+        # @yieldparam [Integer] a
+        # @yieldparam [Float] b
+        # @yieldreturn [Boolean] c
         sig { params(x: String, blk: T.proc.params(a: Integer, b: Float).returns(T::Boolean)).returns(T::Boolean) }
         def foo(x, &blk); end
       end
@@ -262,6 +270,9 @@ describe Sord::RbiGenerator do
     expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       module A
+        # @yieldparam [Symbol] foo
+        # @yieldreturn [void]
+        # @return [void]
         sig { params(blk: T.proc.params(foo: Symbol).void).void }
         def self.foo(&blk); end
       end
@@ -281,6 +292,9 @@ describe Sord::RbiGenerator do
     expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       module A
+        # @param [Integer] x
+        # @param [Array<String>] y
+        # @return [void]
         sig { params(x: Integer, y: T::Array[String]).void }
         def foo(x, *y); end
       end
@@ -302,6 +316,11 @@ describe Sord::RbiGenerator do
     expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       module A
+        # @param [Integer] a
+        # @param [String] b
+        # @param [Float] c
+        # @param [Object] d
+        # @return [void]
         sig do
           params(
             a: Integer,
@@ -328,6 +347,7 @@ describe Sord::RbiGenerator do
     expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       module A
+        # @return [Integer]
         sig { returns(Integer) }
         def x; end
 
@@ -376,6 +396,8 @@ describe Sord::RbiGenerator do
       # typed: strong
       module A
         # sord infer - argument name in single @param inferred as "a"
+        # @param [String]
+        # @return [void]
         sig { params(a: String).void }
         def x(a); end
       end
@@ -395,6 +417,8 @@ describe Sord::RbiGenerator do
       # typed: strong
       module A
         # sord infer - argument name in single @param inferred as "value"
+        # @param [String]
+        # @return [String]
         sig { params(value: String).returns(String) }
         def x=(value); end
       end
@@ -417,6 +441,10 @@ describe Sord::RbiGenerator do
       module A
         # sord omit - no YARD type given for "a", using T.untyped
         # sord omit - no YARD type given for "c", using T.untyped
+        # @param [String] 
+        # @param [Integer] b
+        # @param [Boolean]
+        # @return [void]
         sig { params(a: T.untyped, b: Integer, c: T.untyped).void }
         def x(a, b, c); end
       end
@@ -439,11 +467,13 @@ describe Sord::RbiGenerator do
     expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       class A
+        # @return [void]
         sig { void }
         def x; end
       end
 
       class B < A
+        # @return [void]
         sig { void }
         def y; end
       end
@@ -471,12 +501,18 @@ describe Sord::RbiGenerator do
       # typed: strong
       class A
         # sord omit - no YARD type given for "b:", using T.untyped
+        # @param [String] a
+        # @return [void]
         sig { params(a: T.nilable(String), b: T.untyped).void }
         def x(a: nil, b: nil); end
 
+        # @param [String] a
+        # @return [void]
         sig { params(a: T.nilable(String)).void }
         def y(a = nil); end
 
+        # @param [String, nil] a
+        # @return [void]
         sig { params(a: T.nilable(String)).void }
         def z(a = nil); end
       end
@@ -498,6 +534,11 @@ describe Sord::RbiGenerator do
     expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       class A
+        # @param [String] a
+        # @param [String] b
+        # @param [String] c
+        # @param [String] d
+        # @return [void]
         sig do
           params(
             a: String,
@@ -528,6 +569,13 @@ describe Sord::RbiGenerator do
     expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       class A
+        # @param [Array] array
+        # @param [Hash] hash
+        # @param [Range] range
+        # @param [Set] set
+        # @param [Enumerator] enumerator
+        # @param [Enumerable] enumerable
+        # @return [void]
         sig do
           params(
             array: T::Array[T.untyped],
@@ -566,6 +614,7 @@ describe Sord::RbiGenerator do
       end
       
       class A < Alphabet::Letters
+        # @return [void]
         sig { void }
         def x; end
       end

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -11,7 +11,7 @@ describe Sord::RbiGenerator do
   subject do
     # Create an unnamed class to emulate everything required in "options"
     Sord::RbiGenerator.new(
-      comments: true,
+      sord_comments: true,
       break_params: 4,
       replace_errors_with_untyped: false,
       replace_unresolved_with_untyped: false


### PR DESCRIPTION
As suggested in Slack by @connorshea, this adds the original comments to the generated RBIs, which should be displayed in autocompletions by LSP when [this PR](https://github.com/sorbet/sorbet/pull/1499) is merged.

(This PR also includes the change in the `infer-untyped-fix` branch.)