### PR TITLE
Fix an issue where blank parameters were sometimes being treated as though they had descriptions

### DIFF
--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -235,7 +235,7 @@ module Sord
               # Output params in the form of:
               # _@param_ `foo` — Lorem ipsum.
               # _@param_ `foo`
-              if param.text.nil?
+              if param.text.nil? || param.text == ''
                 docs_array << "_@param_ `#{param.name}`"
               else
                 docs_array << "_@param_ `#{param.name}` — #{param.text}"


### PR DESCRIPTION
I noticed this when generating Sord docs for Faker:

```ruby
# Produces a random paragraph
# 
# _@param_ `sentence_count` — Number of sentences to generate
# 
# _@param_ `random_sentences_to_add` — 
# 
# ```ruby
# Faker::Books::Lovecraft.paragraph
#   #=> "Squamous nameless daemoniac fungus ululate. Cyclopean stygian decadent loathsome manuscript tenebrous. Foetid abnormal stench. Dank non-euclidean comprehension eldritch. Charnel singular shunned lurk effulgence fungus."
# ```
# 
# ```ruby
# Faker::Books::Lovecraft.paragraph(sentence_count: 2)
#   #=> "Decadent lurk tenebrous loathsome furtive spectral amorphous gibbous. Gambrel eldritch daemoniac cat madness comprehension stygian effulgence."
# ```
# 
# ```ruby
# Faker::Books::Lovecraft.paragraph(sentence_count: 1, random_sentences_to_add: 1)
#   #=> "Stench cyclopean fainted antiquarian nameless. Antiquarian ululate tenebrous non-euclidean effulgence."
# ```
sig do
  params(
    legacy_sentence_count: T.untyped,
    legacy_random_sentences_to_add: T.untyped,
    sentence_count: Integer,
    random_sentences_to_add: Integer
  ).returns(::String)
end
def self.paragraph(legacy_sentence_count = NOT_GIVEN, legacy_random_sentences_to_add = NOT_GIVEN, sentence_count: 3, random_sentences_to_add: 3); end
```

I'm not entirely sure why, and it seems like the tests should cover this case, but they don't seem to.

With this change, it's generated correctly:

```ruby
# Produces a random sentence
# 
# _@param_ `word_count` — The number of words to have in the sentence
# 
# _@param_ `random_words_to_add`
# 
# ```ruby
# Faker::Books::Lovecraft.sentence
#   #=> "Furtive antiquarian squamous dank cat loathsome amorphous lurk."
# ```
# 
# ```ruby
# Faker::Books::Lovecraft.sentence(word_count: 3)
#   #=> "Daemoniac antediluvian fainted squamous comprehension gambrel nameless singular."
# ```
# 
# ```ruby
# Faker::Books::Lovecraft.sentence(word_count: 3, random_words_to_add: 1)
#   #=> "Amorphous indescribable tenebrous."
# ```
sig do
  params(
    legacy_word_count: T.untyped,
    legacy_random_words_to_add: T.untyped,
    word_count: Integer,
    random_words_to_add: Integer
  ).returns(String)
end
def self.sentence(legacy_word_count = NOT_GIVEN, legacy_random_words_to_add = NOT_GIVEN, word_count: 4, random_words_to_add: 6); end
```