### PR TITLE
Fix an issue with multiline param tags

### DIFF
--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -238,7 +238,7 @@ module Sord
               if param.text.nil?
                 docs_array << "_@param_ `#{param.name}`"
               else
-                docs_array << "_@param_ `#{param.name}` — #{param.text}"
+                docs_array << "_@param_ `#{param.name}` — #{param.text.gsub("\n", " ")}"
               end
             end
 

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -831,6 +831,31 @@ describe Sord::RbiGenerator do
     RUBY
   end
 
+  it 'handles method with multi-line parameter tag' do
+    YARD.parse_string(<<-RUBY)
+      module A
+        # Lorem ipsum dolor.
+        #
+        # @param a [String] Lorem ipsum dolor
+        #   sit amet.
+        #
+        # @return [String]
+        def x(a); end
+      end
+    RUBY
+
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      module A
+        # Lorem ipsum dolor.
+        # 
+        # _@param_ `a` — Lorem ipsum dolor sit amet.
+        sig { params(a: String).returns(String) }
+        def x(a); end
+      end
+    RUBY
+  end
+
   it 'handles methods with @note, @see, and @deprecated' do
     YARD.parse_string(<<-RUBY)
       module A


### PR DESCRIPTION
If you had multi-line param tags, that broke the output RBI.

e.g. given this input:

```ruby
module A
  # Lorem ipsum dolor.
  #
  # @param a [String] Lorem ipsum dolor
  #   sit amet.
  #
  # @return [String]
  def x(a); end
end
```

Sord would provide this output:

```ruby
# typed: strong
module A
  # Lorem ipsum dolor.
  # 
  # _@param_ `a` — Lorem ipsum dolor
sit amet.
  sig { params(a: String).returns(String) }
  def x(a); end
end
```