### PR TITLE
Add a flag to skip constants.

### DIFF
--- a/exe/sord
+++ b/exe/sord
@@ -19,6 +19,7 @@ command :gen do |c|
   c.option '--exclude-messages STRING', String, 'Blacklists a comma-separated string of log message types'
   c.option '--include-messages STRING', String, 'Whitelists a comma-separated string of log message types'
   c.option '--keep-original-comments', 'Retains original YARD comments rather than converting them to Markdown'
+  c.option '--skip-constants', 'Excludes constants from generated RBI'
 
   c.action do |args, options|
     options.default(
@@ -29,7 +30,8 @@ command :gen do |c|
       replace_unresolved_with_untyped: false,
       exclude_messages: nil,
       include_messages: nil,
-      keep_original_comments: false
+      keep_original_comments: false,
+      skip_constants: false
     )
 
     if args.length != 1

--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -39,6 +39,7 @@ module Sord
       @replace_errors_with_untyped = options[:replace_errors_with_untyped]
       @replace_unresolved_with_untyped = options[:replace_unresolved_with_untyped]
       @keep_original_comments = options[:keep_original_comments]
+      @skip_constants = options[:skip_constants]
 
       # Hook the logger so that messages are added as comments to the RBI file
       Logging.add_hook do |type, msg, item|
@@ -323,7 +324,7 @@ module Sord
 
       add_mixins(item)
       add_methods(item)
-      add_constants(item)
+      add_constants(item) unless @skip_constants
 
       item.children.select { |x| [:class, :module].include?(x.type) }
         .each { |child| add_namespace(child) }


### PR DESCRIPTION
This is very useful for generating a valid RBI file without too much hastle.

Resolves #111.