### PR TITLE
Reverse the parameters before sorting.

### DIFF
--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -110,7 +110,7 @@ module Sord
         end
 
         # Sort parameters
-        meth.parameters.sort! { |pair1, pair2| sort_params(pair1, pair2) }
+        meth.parameters.reverse.sort! { |pair1, pair2| sort_params(pair1, pair2) }
         # This is better than iterating over YARD's "@param" tags directly 
         # because it includes parameters without documentation
         # (The gsubs allow for better splat-argument compatibility)

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -939,20 +939,20 @@ describe Sord::RbiGenerator do
       # typed: strong
       module A
         # sord omit - no YARD type given for "a", using T.untyped
-        # sord omit - no YARD type given for "c:", using T.untyped
         # sord omit - no YARD type given for "b:", using T.untyped
+        # sord omit - no YARD type given for "c:", using T.untyped
         # sord omit - no YARD type given for "**rest", using T.untyped
         # sord omit - no YARD return type given, using T.untyped
         sig do
           params(
             a: T.untyped,
-            c: T.untyped,
             b: T.untyped,
+            c: T.untyped,
             rest: T.untyped,
             blk: T.untyped
           ).returns(T.untyped)
         end
-        def x(a, c:, b: [], **rest, &blk); end
+        def x(a, b: [], c:, **rest, &blk); end
       end
     RUBY
   end


### PR DESCRIPTION
The parameters have to be in the same order when generated by Sord vs. Sorbet. This fixes a problem where methods with lots of parameters were being sorted differently by Sord and therefore causing `srb tc` to fail.

```ruby
# Generated by Sord (before this change)
def self.british_driving_licence(
  legacy_initials = T.unsafe(nil),
  legacy_gender = T.unsafe(nil),
  legacy_date_of_birth = T.unsafe(nil),
  legacy_last_name = T.unsafe(nil),
  date_of_birth: Faker::Date.birthday(min_age: 18, max_age: 65),
  last_name: Faker::Name.last_name,
  initials: Faker::Name.initials,
  gender: random_gender
); end

# Generated by Sorbet
def self.british_driving_licence(
  legacy_last_name = nil,
  legacy_initials = nil,
  legacy_gender = nil,
  legacy_date_of_birth = nil,
  last_name: nil,
  initials: nil,
  gender: nil,
  date_of_birth: nil
); end
```

And with this change, the RBI that Sord creates for Faker has far fewer typechecking errors :)