### PR TITLE
Update to Parlour 2.0.

### DIFF
--- a/sord.gemspec
+++ b/sord.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|sorbet)/}) }
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'yard'
   spec.add_dependency 'sorbet-runtime'
-  spec.add_dependency 'commander', '~> 4.4'
-  spec.add_dependency 'parlour', '~> 1.0'
+  spec.add_dependency 'commander', '~> 4.5'
+  spec.add_dependency 'parlour', '~> 2.0'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
And add `sorbet/` to the gemfile's excluded directories. This should make the released gem smaller.