### PR TITLE
Make initialize methods return void by default

### DIFF
--- a/exe/sord
+++ b/exe/sord
@@ -20,7 +20,7 @@ command :gen do |c|
   c.option '--include-messages STRING', String, 'Whitelists a comma-separated string of log message types'
   c.option '--keep-original-comments', 'Retains original YARD comments rather than converting them to Markdown'
   c.option '--skip-constants', 'Excludes constants from generated RBI'
-  c.option '--use-original-initiailize-return', 'Uses the specified return type for #initialize rather than void'
+  c.option '--use-original-initialize-return', 'Uses the specified return type for #initialize rather than void'
 
   c.action do |args, options|
     options.default(
@@ -33,7 +33,7 @@ command :gen do |c|
       include_messages: nil,
       keep_original_comments: false,
       skip_constants: false,
-      use_original_initiailize_return: false,
+      use_original_initialize_return: false,
     )
 
     if args.length != 1

--- a/exe/sord
+++ b/exe/sord
@@ -20,6 +20,7 @@ command :gen do |c|
   c.option '--include-messages STRING', String, 'Whitelists a comma-separated string of log message types'
   c.option '--keep-original-comments', 'Retains original YARD comments rather than converting them to Markdown'
   c.option '--skip-constants', 'Excludes constants from generated RBI'
+  c.option '--use-original-initiailize-return', 'Uses the specified return type for #initialize rather than void'
 
   c.action do |args, options|
     options.default(
@@ -31,7 +32,8 @@ command :gen do |c|
       exclude_messages: nil,
       include_messages: nil,
       keep_original_comments: false,
-      skip_constants: false
+      skip_constants: false,
+      use_original_initiailize_return: false,
     )
 
     if args.length != 1

--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -40,7 +40,7 @@ module Sord
       @replace_unresolved_with_untyped = options[:replace_unresolved_with_untyped]
       @keep_original_comments = options[:keep_original_comments]
       @skip_constants = options[:skip_constants]
-      @use_original_initiailize_return = options[:use_original_initiailize_return]
+      @use_original_initialize_return = options[:use_original_initialize_return]
 
       # Hook the logger so that messages are added as comments to the RBI file
       Logging.add_hook do |type, msg, item|
@@ -192,7 +192,7 @@ module Sord
         end
 
         return_tags = meth.tags('return')
-        returns = if meth.name == :initialize && !@use_original_initiailize_return
+        returns = if meth.name == :initialize && !@use_original_initialize_return
           nil
         elsif return_tags.length == 0
           Logging.omit("no YARD return type given, using T.untyped", meth)

--- a/lib/sord/rbi_generator.rb
+++ b/lib/sord/rbi_generator.rb
@@ -40,6 +40,7 @@ module Sord
       @replace_unresolved_with_untyped = options[:replace_unresolved_with_untyped]
       @keep_original_comments = options[:keep_original_comments]
       @skip_constants = options[:skip_constants]
+      @use_original_initiailize_return = options[:use_original_initiailize_return]
 
       # Hook the logger so that messages are added as comments to the RBI file
       Logging.add_hook do |type, msg, item|
@@ -191,7 +192,9 @@ module Sord
         end
 
         return_tags = meth.tags('return')
-        returns = if return_tags.length == 0
+        returns = if meth.name == :initialize && !@use_original_initiailize_return
+          nil
+        elsif return_tags.length == 0
           Logging.omit("no YARD return type given, using T.untyped", meth)
           'T.untyped'
         elsif return_tags.length == 1 && return_tags&.first&.types&.first&.downcase == "void"

--- a/spec/rbi_generator_spec.rb
+++ b/spec/rbi_generator_spec.rb
@@ -1010,4 +1010,23 @@ describe Sord::RbiGenerator do
       end
     RUBY
   end
+
+  it 'generates constructors which return void' do
+    YARD.parse_string(<<-RUBY)
+      class A
+        # @param [String] a
+        # @return [A]
+        def initialize(a); end
+      end
+    RUBY
+
+    expect(subject.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      class A
+        # _@param_ `a`
+        sig { params(a: String).void }
+        def initialize(a); end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Also adds `--use-original-initiailize-return` to use the old behaviour.

Closes #105.