### PR TITLE
CHANGED: Correct bundler [DEPRECATION] issue for bundler >= 2.1

### DIFF
--- a/lib/sord/parlour_plugin.rb
+++ b/lib/sord/parlour_plugin.rb
@@ -41,7 +41,7 @@ module Sord
       if options[:regenerate]
         begin
           Sord::Logging.info('Running YARD...')
-          Bundler.with_clean_env do
+          Sord::ParlourPlugin.with_clean_env do
             system('bundle exec yard')
           end
         rescue Errno::ENOENT
@@ -58,6 +58,15 @@ module Sord
       Sord::RbiGenerator.new(options).run
 
       true
+    end
+
+    def self.with_clean_env &block
+      meth = if Bundler.respond_to?(:with_unbundled_env)
+               :with_unbundled_env
+             else
+               :with_clean_env
+            end
+      Bundler.send meth, &block
     end
   end
 end


### PR DESCRIPTION
This request is to remove the bundler deprecation issue if using bundler >= 2.1. It should also fallback to running `Bundler.with_clean_env` if the bundler version is < 2.1.

![Screen Shot 2020-04-17 at 6 46 37 PM](https://user-images.githubusercontent.com/5805/79624208-76f33700-80dd-11ea-8649-7b84335a2452.png)
