### PR TITLE
handle ruby 3 removing sorted set

### DIFF
--- a/lib/sord/resolver.rb
+++ b/lib/sord/resolver.rb
@@ -39,8 +39,12 @@ module Sord
       # This prints some deprecation warnings, so suppress them
       prev_stderr = $stderr
       $stderr = StringIO.new
+      
+      major = RUBY_VERSION.split('.').first.to_i
+      sorted_set_removed = major >= 3 
 
       Object.constants
+        .reject { |x| sorted_set_removed && x == :SortedSet }
         .select { |x| Object.const_get(x).is_a?(Class) }
         .map(&:to_s)
     ensure


### PR DESCRIPTION
without this patch on ruby 3 running `sord defs.rbi`

```
[ERROR] The `SortedSet` class has been extracted from the `set` library.You must use the `sorted_set` gem or other alternatives.
         /home/stephen/.rbenv/versions/3.0.0/lib/ruby/3.0.0/set/sorted_set.rb:4:in `rescue in <top (required)>'
         /home/stephen/.rbenv/versions/3.0.0/lib/ruby/3.0.0/set/sorted_set.rb:1:in `<top (required)>'
         <internal:/home/stephen/.rbenv/versions/3.0.0/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
         <internal:/home/stephen/.rbenv/versions/3.0.0/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
         /home/stephen/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/sord-3.0.0/lib/sord/resolver.rb:44:in `const_get'
         /home/stephen/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/sord-3.0.0/lib/sord/resolver.rb:44:in `block in builtin_classes'
```

This is because they have left it on Object.constants but when you get it :boom:. Not sure if this is the right way to handle this, open to feedback!