### PR TITLE
Add unary minus default parameter workaround

### DIFF
--- a/lib/sord/generator.rb
+++ b/lib/sord/generator.rb
@@ -250,7 +250,7 @@ module Sord
         # because it includes parameters without documentation
         # (The gsubs allow for better splat-argument compatibility)
         parameter_names_and_defaults_to_tags = meth.parameters.map do |name, default|
-          [[name, default], meth.tags('param')
+          [[name, fix_default_if_unary_minus(default)], meth.tags('param')
             .find { |p| p.name&.gsub('*', '')&.gsub(':', '') == name.gsub('*', '').gsub(':', '') }]
         end.to_h
 
@@ -596,6 +596,21 @@ module Sord
       }
 
       return pair_type_order[pair1_type] <=> pair_type_order[pair2_type]
+    end
+
+    # Removes the last character of a default parameter value if it begins with
+    # '-', working around a bug in YARD. (See lsegal/yard #894)
+    #
+    # @param [String] default
+    # @return [String]
+    def fix_default_if_unary_minus(default)
+      if default.nil?
+        nil
+      elsif default[0] == '-'
+        default[0..-2]
+      else
+        default
+      end
     end
   end
 end

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -1652,4 +1652,48 @@ describe Sord::Generator do
       end
     RUBY
   end
+
+  it 'works around the YARD "duplicated character after negative argument" bug' do
+    YARD.parse_string(<<-RUBY)
+      class A
+        def x(a, b, c = -1, d = -2); end
+        def y(a, b, c = -Something.complex(2, 3), d = -Something::ELSE); end
+      end
+    RUBY
+
+    expect(rbi_gen.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      class A
+        # sord omit - no YARD type given for "a", using untyped
+        # sord omit - no YARD type given for "b", using untyped
+        # sord omit - no YARD type given for "c", using untyped
+        # sord omit - no YARD type given for "d", using untyped
+        # sord omit - no YARD return type given, using untyped
+        sig do
+          params(
+            a: T.untyped,
+            b: T.untyped,
+            c: T.untyped,
+            d: T.untyped
+          ).returns(T.untyped)
+        end
+        def x(a, b, c = -1, d = -2); end
+
+        # sord omit - no YARD type given for "a", using untyped
+        # sord omit - no YARD type given for "b", using untyped
+        # sord omit - no YARD type given for "c", using untyped
+        # sord omit - no YARD type given for "d", using untyped
+        # sord omit - no YARD return type given, using untyped
+        sig do
+          params(
+            a: T.untyped,
+            b: T.untyped,
+            c: T.untyped,
+            d: T.untyped
+          ).returns(T.untyped)
+        end
+        def y(a, b, c = -Something.complex(2, 3), d = -Something::ELSE); end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This adds a workaround for #75 (which is a bug in YARD, not Sord) by checking for a unary minus at the beginning of a default parameter value, and if one is there, chops off its final character.

Looking at the original example from haml, previously:

```ruby
sig { params(index: T.untyped).returns(T.untyped) }
def rstrip_buffer!(index = -1)); end
```

Now:

```
sig { params(index: T.untyped).returns(T.untyped) }
def rstrip_buffer!(index = -1); end
```

(cc @connorshea)