### PR TITLE
Add constant type for rbs

### DIFF
--- a/lib/sord/generator.rb
+++ b/lib/sord/generator.rb
@@ -127,7 +127,19 @@ module Sord
             c.add_comments(constant.docstring.all.split("\n"))
           end
         when :rbs
-          @current_object.create_constant(constant_name, type: Parlour::Types::Untyped.new) do |c|
+          return_tags = constant.tags('return')
+          returns = if return_tags.empty?
+            Logging.omit("no YARD return type given, using untyped", constant.to_s)
+            Parlour::Types::Untyped.new
+          else
+            TypeConverter.yard_to_parlour(
+              return_tags.map(&:types).flatten,
+              constant,
+              @replace_errors_with_untyped,
+              @replace_unresolved_with_untyped
+            )
+          end
+          @current_object.create_constant(constant_name, type: returns) do |c|
             c.add_comments(constant.docstring.all.split("\n"))
           end
         end

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -888,20 +888,24 @@ describe Sord::Generator do
   it 'handles constants' do
     YARD.parse_string(<<-RUBY)
       class A
-        EXAMPLE_CONSTANT = 'Foo'
+        EXAMPLE_UNTYPED_CONSTANT = 'Foo'
+        # @return [String]
+        EXAMPLE_TYPED_CONSTANT = 'Bar'
       end
     RUBY
 
     expect(rbi_gen.generate.strip).to eq fix_heredoc(<<-RUBY)
       # typed: strong
       class A
-        EXAMPLE_CONSTANT = T.let('Foo', T.untyped)
+        EXAMPLE_UNTYPED_CONSTANT = T.let('Foo', T.untyped)
+        EXAMPLE_TYPED_CONSTANT = T.let('Bar', T.untyped)
       end
     RUBY
 
     expect(rbs_gen.generate.strip).to eq fix_heredoc(<<-RUBY)
       class A
-        EXAMPLE_CONSTANT: untyped
+        EXAMPLE_UNTYPED_CONSTANT: untyped
+        EXAMPLE_TYPED_CONSTANT: String
       end
     RUBY
   end


### PR DESCRIPTION
In this PR, add type definition(rbs) to constant using `@return`.
If there is no `@return`, it continue to be untyped.

We can also write `@return` in constant, but I'm not sure if that's the right thing to do. 
But I couldn't think of any other way to add the type.

example:
- ruby
  ```ruby
  class A
    # @return [String]
    EXAMPLE_CONSTANT = 'Bar'
  end
  ```
- rbs
  ```ruby
  class A
    EXAMPLE_CONSTANT: String
  end
  ```

I haven't changed rbi, so I couldn't determine if https://github.com/AaronC81/sord/issues/128 could be closed.