### PR TITLE
Explcitly handle namespacing from root (::X)

### DIFF
--- a/lib/sord/resolver.rb
+++ b/lib/sord/resolver.rb
@@ -24,6 +24,10 @@ module Sord
     # @return [Array<String>]
     def self.paths_for(name)
       prepare
+
+      # If the name starts with ::, then we've been given an explicit path from root - just use that
+      return [name] if name.start_with?('::')
+
       (@@names_to_paths[name.split('::').last] || [])
         .select { |x| x.end_with?(name) }
     end

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -1700,4 +1700,49 @@ describe Sord::Generator do
       end
     RUBY
   end
+
+  it 'handles namespacing from root' do
+    YARD.parse_string(<<-RUBY)
+      class X
+      end
+
+      class Y
+        class X
+        end
+      end
+
+      class Z
+        # @return [Y::X]
+        def y_x; end
+
+        # @return [::X]
+        def x; end
+
+        # @return [X]
+        def ambiguous_x; end
+      end
+    RUBY
+
+    expect(rbi_gen.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      class X
+      end
+
+      class Y
+        class X
+        end
+      end
+
+      class Z
+        sig { returns(Y::X) }
+        def y_x; end
+
+        sig { returns(::X) }
+        def x; end
+
+        sig { returns(X) }
+        def ambiguous_x; end
+      end
+    RUBY
+  end
 end

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -141,4 +141,23 @@ describe Sord::Resolver do
     subject.prepare
     expect(subject.resolvable?('A', at('A::B::A::D'))).to be true
   end
+
+  it 'can resolve from the root namespace' do
+    YARD.parse_string(<<-RUBY)
+      module A
+        class B
+        end
+      end
+
+      class B
+      end
+    RUBY
+
+    subject.prepare
+
+    expect(subject.path_for('A::B')).to eq 'A::B'
+    expect(subject.path_for('::B')).to eq '::B'
+
+    expect(subject.path_for('B')).to be nil # Ambiguous
+  end
 end


### PR DESCRIPTION
Fixes #132.

The resolver will now look for uses of `::X` and handle them properly, leaving the given class paths as they are given verbatim.