### PR TITLE
second curly bracket is removed when block is used as a param

### DIFF
--- a/lib/sord/generator.rb
+++ b/lib/sord/generator.rb
@@ -614,11 +614,11 @@ module Sord
     # '-', working around a bug in YARD. (See lsegal/yard #894)
     #
     # @param [String] default
-    # @return [String]
+    # @return [String, nil]
     def fix_default_if_unary_minus(default)
       if default.nil?
         nil
-      elsif default[0] == '-'
+      elsif default[0] == '-' && !default.include?('->')
         default[0..-2]
       else
         default

--- a/lib/sord/generator.rb
+++ b/lib/sord/generator.rb
@@ -618,7 +618,7 @@ module Sord
     def fix_default_if_unary_minus(default)
       if default.nil?
         nil
-      elsif default[0] == '-' && !default.include?('->')
+      elsif default[0] == '-' && !default.start_with?('->')
         default[0..-2]
       else
         default

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -1704,7 +1704,9 @@ describe Sord::Generator do
   it 'works with inline block as param' do
     YARD.parse_string(<<-RUBY)
       class A
-        def x(a: ->() {}); end
+        def x(a: -> () {}); end
+        def y(a: ->() {}); end
+        def z(a: -> {}); end
       end
     RUBY
 
@@ -1714,7 +1716,17 @@ describe Sord::Generator do
         # sord omit - no YARD type given for "a:", using untyped
         # sord omit - no YARD return type given, using untyped
         sig { params(a: T.untyped).returns(T.untyped) }
-        def x(a: ->() {}); end
+        def x(a: -> () {}); end
+
+        # sord omit - no YARD type given for "a:", using untyped
+        # sord omit - no YARD return type given, using untyped
+        sig { params(a: T.untyped).returns(T.untyped) }
+        def y(a: ->() {}); end
+
+        # sord omit - no YARD type given for "a:", using untyped
+        # sord omit - no YARD return type given, using untyped
+        sig { params(a: T.untyped).returns(T.untyped) }
+        def z(a: -> {}); end
       end
     RUBY
   end

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -1700,4 +1700,22 @@ describe Sord::Generator do
       end
     RUBY
   end
+
+  it 'works with inline block as param' do
+    YARD.parse_string(<<-RUBY)
+      class A
+        def x(a: ->() {}); end
+      end
+    RUBY
+
+    expect(rbi_gen.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      class A
+        # sord omit - no YARD type given for "a:", using untyped
+        # sord omit - no YARD return type given, using untyped
+        sig { params(a: T.untyped).returns(T.untyped) }
+        def x(a: ->() {}); end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
failing test