### PR TITLE
Add --hide-private to omit anything with visibility private

### DIFF
--- a/exe/sord
+++ b/exe/sord
@@ -22,6 +22,7 @@ command :gen do |c|
   c.option '--include-messages STRING', String, 'Whitelists a comma-separated string of log message types'
   c.option '--keep-original-comments', 'Retains original YARD comments rather than converting them to Markdown'
   c.option '--skip-constants', 'Excludes constants from generated file'
+  c.option '--hide-private', 'Exclude any object marked with @!visibility private'
   c.option '--use-original-initialize-return', 'Uses the specified return type for #initialize rather than void'
   c.option '--exclude-untyped', 'Exclude methods and attributes with untyped return values'
 
@@ -34,6 +35,7 @@ command :gen do |c|
       break_params: 4,
       replace_errors_with_untyped: false,
       replace_unresolved_with_untyped: false,
+      hide_private: false,
       exclude_messages: nil,
       include_messages: nil,
       keep_original_comments: false,
@@ -86,7 +88,7 @@ command :gen do |c|
 
     plugin.parlour = klass.new(break_params: plugin_options[:break_params])
     plugin.generate(plugin.parlour.root)
-    
+
     File.write(args.first, plugin.parlour.send(generator_method))
   end
 end

--- a/lib/sord/generator.rb
+++ b/lib/sord/generator.rb
@@ -28,6 +28,7 @@ module Sord
     # @option options [Integer] break_params
     # @option options [Boolean] replace_errors_with_untyped
     # @option options [Boolean] replace_unresolved_with_untyped
+    # @option options [Boolean] hide_private
     # @option options [Boolean] comments
     # @option options [Parlour::Generator] generator
     # @option options [Parlour::TypedObject] root
@@ -53,6 +54,7 @@ module Sord
       @replace_errors_with_untyped = options[:replace_errors_with_untyped]
       @replace_unresolved_with_untyped = options[:replace_unresolved_with_untyped]
       @keep_original_comments = options[:keep_original_comments]
+      @hide_private = options[:hide_private]
       @skip_constants = options[:skip_constants]
       @use_original_initialize_return = options[:use_original_initialize_return]
       @exclude_untyped = options[:exclude_untyped]
@@ -62,9 +64,9 @@ module Sord
         # Hack: the "exclude untyped" log message needs to print somewhere, but
         # if there's no future object for that comment to associate with, it'll
         # never be printed!
-        # Instead, add an arbitrary containing the comment 
+        # Instead, add an arbitrary containing the comment
         if opts[:immediate]
-          @current_object.create_arbitrary(code: "# sord #{type} - #{msg}") 
+          @current_object.create_arbitrary(code: "# sord #{type} - #{msg}")
         else
           @current_object.add_comment_to_next_child("sord #{type} - #{msg}")
         end
@@ -538,6 +540,7 @@ module Sord
     # @param [YARD::CodeObjects::NamespaceObject] item
     # @return [void]
     def add_namespace(item)
+      return if @hide_private && item.visibility == :private
       count_namespace
 
       superclass = nil

--- a/lib/sord/generator.rb
+++ b/lib/sord/generator.rb
@@ -122,6 +122,7 @@ module Sord
       inserted_constant_names = Set.new
 
       item.constants(included: false).each do |constant|
+        next if @hide_private && constant.visibility == :private
         # Take a constant (like "A::B::CONSTANT"), split it on each '::', and
         # set the constant name to the last string in the array.
         constant_name = constant.to_s.split('::').last
@@ -254,6 +255,7 @@ module Sord
     # @return [void]
     def add_methods(item)
       item.meths(inherited: false).each do |meth|
+        next if @hide_private && meth.visibility == :private
         count_method
 
         # If the method is an alias, skip it so we don't define it as a
@@ -449,10 +451,12 @@ module Sord
           # Get all given types
           yard_types = []
           if reader
+            next if @hide_private && reader.visibility == :private
             yard_types += reader.tags('return').flat_map(&:types).compact.reject { |x| x.downcase == 'void' } +
               reader.tags('param').flat_map(&:types)
           end
           if writer
+            next if @hide_private && writer.visibility == :private
             yard_types += writer.tags('return').flat_map(&:types).compact.reject { |x| x.downcase == 'void' } +
               writer.tags('param').flat_map(&:types)
           end


### PR DESCRIPTION
Currently, adding a `@!visibility private` tag does not affect sord's output. This PR adds a `--hide-private` option to not include anything tagged this way. Some examples might be monkey patching existing code (where our patch might inadvertently override better-documented existing methods), or more complex metaprogramming that sord might be confused by.