### PR TITLE
Load gem-included types

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,10 +6,10 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby: [2.7, 3.0, 3.1]
     continue-on-error: false
-      
-    runs-on: ubuntu-latest    
+
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/lib/sord/resolver.rb
+++ b/lib/sord/resolver.rb
@@ -23,7 +23,11 @@ module Sord
 
     def self.load_gem_objects(hash)
       all_decls = []
-      RBS::CLI::LibraryOptions.new.loader.load(env: all_decls)
+      begin
+        RBS::CLI::LibraryOptions.new.loader.load(env: all_decls)
+      rescue RBS::Collection::Config::CollectionNotAvailable
+        Sord::Logging.warn("Could not load RBS collection - run rbs collection install for dependencies")
+      end
       add_rbs_objects_to_paths(all_decls, hash)
 
       gem_paths = Bundler.load.specs.map(&:full_gem_path)

--- a/lib/sord/resolver.rb
+++ b/lib/sord/resolver.rb
@@ -1,23 +1,74 @@
 # typed: false
 require 'stringio'
+require 'rbs'
 
 module Sord
   module Resolver
     # @return [void]
     def self.prepare
+      return @names_to_paths if @names_to_paths
+
+      gem_objects = {}
+      load_gem_objects(gem_objects)
+
       # Construct a hash of class names to full paths
-      @@names_to_paths ||= YARD::Registry.all(:class)
+      @names_to_paths = YARD::Registry.all(:class)
         .group_by(&:name)
         .map { |k, v| [k.to_s, v.map(&:path)] }
         .to_h
-        .merge(builtin_classes.map { |x| [x, [x]] }.to_h) do |k, a, b|
-          a | b
+        .merge(builtin_classes.map { |x| [x, [x]] }.to_h) { |_k, a, b| a | b }
+        .merge(gem_objects) { |_k, a, b| a | b }
+    end
+
+    def self.load_gem_objects(hash)
+      gem_paths = Bundler.load.specs.map(&:full_gem_path)
+      gem_paths.each do |path|
+        Dir["#{path}/rbi/**/*.rbi"].each do |sigfile|
+          tree = Parlour::TypeLoader.load_file(sigfile)
+          add_rbi_objects_to_paths(tree.children, hash)
         end
+      end
+      gem_paths.each do |path|
+        all_decls = []
+        RBS::EnvironmentLoader.new(core_root: Pathname.new("#{path}/sig")).load(env: all_decls)
+        add_rbs_objects_to_paths(all_decls, hash)
+      end
+    end
+
+    def self.add_rbs_objects_to_paths(all_decls, names_to_paths, path=[])
+      klasses = [
+        RBS::AST::Declarations::Module,
+        RBS::AST::Declarations::Class,
+        RBS::AST::Declarations::Constant
+      ]
+      all_decls.each do |decl|
+        next unless klasses.include?(decl.class)
+        name = decl.name.to_s
+        new_path = path + [name]
+        names_to_paths[name] ||= []
+        names_to_paths[name] << new_path.join('::')
+        add_rbs_objects_to_paths(decl.members, names_to_paths, new_path) if decl.respond_to?(:members)
+      end
+    end
+
+    def self.add_rbi_objects_to_paths(nodes, names_to_paths, path=[])
+      klasses = [
+        Parlour::RbiGenerator::Constant,
+        Parlour::RbiGenerator::ModuleNamespace,
+        Parlour::RbiGenerator::ClassNamespace
+      ]
+      nodes.each do |node|
+        next unless klasses.include?(node.class)
+        new_path = path + [node.name]
+        names_to_paths[node.name] ||= []
+        names_to_paths[node.name] << new_path.join('::')
+        add_rbi_objects_to_paths(node.children, names_to_paths, new_path) if node.respond_to?(:children)
+      end
     end
 
     # @return [void]
     def self.clear
-      @@names_to_paths = nil
+      @names_to_paths = nil
     end
 
     # @param [String] name
@@ -28,7 +79,7 @@ module Sord
       # If the name starts with ::, then we've been given an explicit path from root - just use that
       return [name] if name.start_with?('::')
 
-      (@@names_to_paths[name.split('::').last] || [])
+      (@names_to_paths[name.split('::').last] || [])
         .select { |x| x.end_with?(name) }
     end
 
@@ -43,9 +94,9 @@ module Sord
       # This prints some deprecation warnings, so suppress them
       prev_stderr = $stderr
       $stderr = StringIO.new
-      
+
       major = RUBY_VERSION.split('.').first.to_i
-      sorted_set_removed = major >= 3 
+      sorted_set_removed = major >= 3
 
       Object.constants
         .reject { |x| sorted_set_removed && x == :SortedSet }

--- a/lib/sord/resolver.rb
+++ b/lib/sord/resolver.rb
@@ -23,15 +23,16 @@ module Sord
     def self.load_gem_objects(hash)
       gem_paths = Bundler.load.specs.map(&:full_gem_path)
       gem_paths.each do |path|
-        Dir["#{path}/rbi/**/*.rbi"].each do |sigfile|
-          tree = Parlour::TypeLoader.load_file(sigfile)
-          add_rbi_objects_to_paths(tree.children, hash)
+        if File.exists?("#{path}/rbi")
+          Dir["#{path}/rbi/**/*.rbi"].each do |sigfile|
+            tree = Parlour::TypeLoader.load_file(sigfile)
+            add_rbi_objects_to_paths(tree.children, hash)
+          end
+        elsif File.exists?("#{path}/sig")
+          all_decls = []
+          RBS::EnvironmentLoader.new(core_root: Pathname.new("#{path}/sig")).load(env: all_decls)
+          add_rbs_objects_to_paths(all_decls, hash)
         end
-      end
-      gem_paths.each do |path|
-        all_decls = []
-        RBS::EnvironmentLoader.new(core_root: Pathname.new("#{path}/sig")).load(env: all_decls)
-        add_rbs_objects_to_paths(all_decls, hash)
       end
     end
 

--- a/sord.gemspec
+++ b/sord.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sorbet-runtime'
   spec.add_dependency 'commander', '~> 4.5'
   spec.add_dependency 'parlour', '~> 5.0'
+  spec.add_dependency 'rbs', '~> 2.0'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -160,4 +160,9 @@ describe Sord::Resolver do
 
     expect(subject.path_for('B')).to be nil # Ambiguous
   end
+
+  it 'resolves included gem rbi files' do
+    subject.prepare
+    expect(subject.path_for('Parlour::TypeLoader')).to eq 'Parlour::TypeLoader'
+  end
 end


### PR DESCRIPTION
When trying to add RBS to a repo of mine, I ran into an issue where sord was complaining that it couldn't find a constant in one of the included gems - this was despite the fact that the included gem had a `sig/defs.rbs` file as the convention is for generated RBS files.

This update pulls in any RBS or RBI signatures to the set of constants that sord knows about.

We can update this in the future to pull in from `sorbet-typed` or any other source of RBI/RBS files.

For now I made this an automatic change (i.e. not part of a setting), because I'm not really sure why someone would specifically *not* want to type constants that gems make public. Feedback is welcome!

Related to #147.