### PR TITLE
Don't output documentation when rerunning YARD

### DIFF
--- a/lib/sord/parlour_plugin.rb
+++ b/lib/sord/parlour_plugin.rb
@@ -42,17 +42,17 @@ module Sord
         Sord::Logging.error('No output format given; please specify --rbi or --rbs')
         exit 1
       end
-  
+
       if (options[:rbi] && options[:rbs])
         Sord::Logging.error('You cannot specify both --rbi and --rbs; please use only one')
         exit 1
       end
-  
+
       if options[:regenerate]
         begin
           Sord::Logging.info('Running YARD...')
           Sord::ParlourPlugin.with_clean_env do
-            system('bundle exec yard')
+            system('bundle exec yard --no-output')
           end
         rescue Errno::ENOENT
           Sord::Logging.error('The YARD tool could not be found on your PATH.')
@@ -63,7 +63,7 @@ module Sord
       end
 
       options[:mode] = \
-        if options[:rbi] then :rbi elsif options[:rbs] then :rbs end 
+        if options[:rbi] then :rbi elsif options[:rbs] then :rbs end
       options[:parlour] = @parlour
       options[:root] = root
 


### PR DESCRIPTION
Regenerating YARD is only useful for `sord` in that it parses the source files and outputs the `yardoc` database. The actual HTML files are of no purpose. This updates the `yard` command so that HTML files are not output. This makes `sord` much, much faster even when regenerating documentation.

We can decide if we want to put this behind a setting or not - it is a breaking change, but I don't really see any point to the current behavior, and if anyone wants to actually generate documentation I think it makes more sense for them to run `yard` manually.