### PR TITLE
Support custom tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Sord also takes some flags to alter the generated file:
     (You cannot specify both `--include-messages` and `--exclude-messages`.)
   - `--exclude-untyped`: Exclude methods and attributes with untyped return
     values.
+  - `--tags TAGS`: Provide a list of comma-separated tags as understood by the
+    `yard` command. E.g. `--tags 'mytag:My Description,mytag2:My New Description'
 
 ## Example
 

--- a/exe/sord
+++ b/exe/sord
@@ -25,6 +25,7 @@ command :gen do |c|
   c.option '--hide-private', 'Exclude any object marked with @!visibility private'
   c.option '--use-original-initialize-return', 'Uses the specified return type for #initialize rather than void'
   c.option '--exclude-untyped', 'Exclude methods and attributes with untyped return values'
+  c.option '--tags TAGS', Array, 'Tag parameters for the YARD command'
 
   c.action do |args, options|
     options.default(
@@ -42,6 +43,7 @@ command :gen do |c|
       skip_constants: false,
       use_original_initialize_return: false,
       exclude_untyped: false,
+      tags: [],
     )
 
     if args.length != 1

--- a/lib/sord/parlour_plugin.rb
+++ b/lib/sord/parlour_plugin.rb
@@ -1,5 +1,6 @@
 # typed: true
 require 'parlour'
+require 'yard/tags/library'
 
 module Sord
   class ParlourPlugin < Parlour::Plugin
@@ -42,17 +43,21 @@ module Sord
         Sord::Logging.error('No output format given; please specify --rbi or --rbs')
         exit 1
       end
-  
+
       if (options[:rbi] && options[:rbs])
         Sord::Logging.error('You cannot specify both --rbi and --rbs; please use only one')
         exit 1
       end
-  
+
       if options[:regenerate]
         begin
           Sord::Logging.info('Running YARD...')
           Sord::ParlourPlugin.with_clean_env do
-            system('bundle exec yard')
+            tag_param = ''
+            options[:tags]&.each do |tag|
+              tag_param += "--tag #{tag} "
+            end
+            system("bundle exec yard #{tag_param}")
           end
         rescue Errno::ENOENT
           Sord::Logging.error('The YARD tool could not be found on your PATH.')
@@ -63,13 +68,24 @@ module Sord
       end
 
       options[:mode] = \
-        if options[:rbi] then :rbi elsif options[:rbs] then :rbs end 
+        if options[:rbi] then :rbi elsif options[:rbs] then :rbs end
       options[:parlour] = @parlour
       options[:root] = root
+
+      add_custom_tags
 
       Sord::Generator.new(options).run
 
       true
+    end
+
+    def add_custom_tags
+      return if options[:tags].empty?
+
+      options[:tags].each do |tag|
+        name, description = tag.split(':')
+        YARD::Tags::Library.define_tag(description, name)
+      end
     end
 
     def self.with_clean_env &block


### PR DESCRIPTION
Currently, when using custom tags (like `@override`), `sord` reports an error every time it encounters it. This PR adds the `--tags` option, which allows passing custom tags into the `sord` command which will suppress these errors.