### PR TITLE
Add conversion to RBS built-in duck type interfaces

### DIFF
--- a/lib/sord/generator.rb
+++ b/lib/sord/generator.rb
@@ -327,8 +327,7 @@ module Sord
             params = yieldparams.map.with_index do |param, i|
               Parlour::Types::Proc::Parameter.new(
                 param.name&.gsub('*', '') || "arg#{i}",
-                TypeConverter.yard_to_parlour(param.types, meth, @type_converter_config)                
-                TypeConverter.yard_to_parlour(param.types, meth, @replace_errors_with_untyped, @replace_unresolved_with_untyped)
+                TypeConverter.yard_to_parlour(param.types, meth, @type_converter_config)
               )
             end
             returns = TypeConverter.yard_to_parlour(yieldreturn, meth, @type_converter_config)

--- a/lib/sord/generator.rb
+++ b/lib/sord/generator.rb
@@ -59,6 +59,12 @@ module Sord
       @use_original_initialize_return = options[:use_original_initialize_return]
       @exclude_untyped = options[:exclude_untyped]
 
+      @type_converter_config = TypeConverter::Configuration.new(
+        output_language: @mode,
+        replace_errors_with_untyped: @replace_errors_with_untyped,
+        replace_unresolved_with_untyped: @replace_unresolved_with_untyped,
+      )
+
       # Hook the logger so that messages are added as comments
       Logging.add_hook do |type, msg, item, **opts|
         # Hack: the "exclude untyped" log message needs to print somewhere, but
@@ -147,8 +153,7 @@ module Sord
             TypeConverter.yard_to_parlour(
               return_tags.map(&:types).flatten,
               constant,
-              @replace_errors_with_untyped,
-              @replace_unresolved_with_untyped
+              @type_converter_config,
             )
           end
           @current_object.create_constant(constant_name, type: returns) do |c|
@@ -310,7 +315,7 @@ module Sord
           name = name_and_default.first
 
           if tag
-            TypeConverter.yard_to_parlour(tag.types, meth, @replace_errors_with_untyped, @replace_unresolved_with_untyped)
+            TypeConverter.yard_to_parlour(tag.types, meth, @type_converter_config)
           elsif name.start_with? '&'
             # Find yieldparams and yieldreturn
             yieldparams = method_tags(meth, 'yieldparam')
@@ -322,10 +327,10 @@ module Sord
             params = yieldparams.map do |param|
               Parlour::Types::Proc::Parameter.new(
                 param.name.gsub('*', ''),
-                TypeConverter.yard_to_parlour(param.types, meth, @replace_errors_with_untyped, @replace_unresolved_with_untyped)
+                TypeConverter.yard_to_parlour(param.types, meth, @type_converter_config)
               )
             end
-            returns = TypeConverter.yard_to_parlour(yieldreturn, meth, @replace_errors_with_untyped, @replace_unresolved_with_untyped)
+            returns = TypeConverter.yard_to_parlour(yieldreturn, meth, @type_converter_config)
 
             # Create proc types, if possible
             if yieldparams.empty? && yieldreturn.nil?
@@ -344,7 +349,7 @@ module Sord
                 && method_tag(meth, 'param').types
 
                 Logging.infer("argument name in single @param inferred as #{parameter_names_and_defaults_to_tags.first.first.first.inspect}", meth)
-                next TypeConverter.yard_to_parlour(method_tag(meth, 'param').types, meth, @replace_errors_with_untyped, @replace_unresolved_with_untyped)
+                next TypeConverter.yard_to_parlour(method_tag(meth, 'param').types, meth, @type_converter_config)
               else
                 Logging.omit("no YARD type given for #{name.inspect}, using untyped", meth)
                 next Parlour::Types::Untyped.new
@@ -357,7 +362,7 @@ module Sord
               next Parlour::Types::Untyped.new
             end
             inferred_type = TypeConverter.yard_to_parlour(
-              return_types, meth, @replace_errors_with_untyped, @replace_unresolved_with_untyped)
+              return_types, meth, @type_converter_config)
 
             Logging.infer("inferred type of parameter #{name.inspect} as #{inferred_type.describe} using getter's return type", meth)
             inferred_type
@@ -369,7 +374,7 @@ module Sord
               && method_tag(meth, 'param').types
 
               Logging.infer("argument name in single @param inferred as #{parameter_names_and_defaults_to_tags.first.first.first.inspect}", meth)
-              TypeConverter.yard_to_parlour(method_tag(meth, 'param').types, meth, @replace_errors_with_untyped, @replace_unresolved_with_untyped)
+              TypeConverter.yard_to_parlour(method_tag(meth, 'param').types, meth, @type_converter_config)
             else
               Logging.omit("no YARD type given for #{name.inspect}, using untyped", meth)
               Parlour::Types::Untyped.new
@@ -386,7 +391,7 @@ module Sord
         elsif return_tags.length == 1 && %w{void nil}.include?(return_tags&.first&.types&.first&.downcase)
           nil
         else
-          TypeConverter.yard_to_parlour(method_tag(meth, 'return').types, meth, @replace_errors_with_untyped, @replace_unresolved_with_untyped)
+          TypeConverter.yard_to_parlour(method_tag(meth, 'return').types, meth, @type_converter_config)
         end
 
         rbs_block = nil
@@ -492,7 +497,7 @@ module Sord
             parlour_type = Parlour::Types::Untyped.new
           else
             parlour_type = TypeConverter.yard_to_parlour(
-              yard_types, reader || writer, @replace_errors_with_untyped, @replace_unresolved_with_untyped)
+              yard_types, reader || writer, @type_converter_config)
           end
 
           # Generate attribute

--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -243,5 +243,44 @@ module Sord
         ? Parlour::Types::Untyped.new
         : Parlour::Types::Raw.new("SORD_ERROR_#{name.gsub(/[^0-9A-Za-z_]/i, '')}")
     end
+
+    # Taken from: https://github.com/ruby/rbs/blob/master/core/builtin.rbs
+    # When the latest commit was: 6c847d1
+    #
+    # Interfaces which use generic arguments have been left out, since (as I understand it)
+    # there's no standard way that these are being written in YARD.
+    DUCK_TYPES_TO_RBS_TYPE_NAMES = {
+      "#to_i" => "_ToI",
+      "#to_int" => "_ToInt",
+      "#to_r" => "_ToR",
+      "#to_s" => "_ToS",
+      "#to_str" => "_ToStr",
+      "#to_proc" => "_ToProc",
+      "#to_path" => "_ToPath",
+      "#read" => "_Reader",
+      "#readpartial" => "_ReaderPartial",
+      "#write" => "_Writer",
+      "#rewind" => "_Rewindable",
+      "#to_io" => "_ToIO",
+      "#exception" => "_Exception",
+    }
+
+    # Given a YARD duck type string, attempts to convert it to one of a list of pre-defined RBS
+    # built-in interfaces.
+    #
+    # For example, the common duck type `#to_s` has a built-in RBS equivalent `_ToS`.
+    #
+    # If no such interface exists, returns `nil`.
+    #
+    # @param [String] type
+    # @return [Parlour::Types::Type, nil]
+    def self.duck_type_to_rbs_type(type)
+      type_name = DUCK_TYPES_TO_RBS_TYPE_NAMES[type]
+      if !type_name.nil?
+        Parlour::Types::Raw.new(type_name)
+      else
+        nil
+      end
+    end
   end
 end

--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -177,8 +177,13 @@ module Sord
           Parlour::Types::Raw.new(yard)
         end
       when DUCK_TYPE_REGEX
-        Logging.duck("#{yard} looks like a duck type, replacing with untyped", item)
-        Parlour::Types::Untyped.new
+        if config.output_language == :rbs && (type = duck_type_to_rbs_type(yard))
+          Logging.duck("#{yard} looks like a duck type with an equivalent RBS interface, replacing with #{type.generate_rbs}", item)
+          type
+        else
+          Logging.duck("#{yard} looks like a duck type, replacing with untyped", item)
+          Parlour::Types::Untyped.new
+        end
       when /^#{GENERIC_TYPE_REGEX}$/
         generic_type = $1
         type_parameters = $2

--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -270,9 +270,10 @@ module Sord
     # Taken from: https://github.com/ruby/rbs/blob/master/core/builtin.rbs
     # When the latest commit was: 6c847d1
     #
-    # Interfaces which use generic arguments have been left out, since (as I understand it)
-    # there's no standard way that these are being written in YARD.
+    # Interfaces which use generic arguments have those arguments as `untyped`, since I'm not aware
+    # of any standard way that these are specified.
     DUCK_TYPES_TO_RBS_TYPE_NAMES = {
+      # Concrete
       "#to_i" => "_ToI",
       "#to_int" => "_ToInt",
       "#to_r" => "_ToR",
@@ -286,6 +287,11 @@ module Sord
       "#rewind" => "_Rewindable",
       "#to_io" => "_ToIO",
       "#exception" => "_Exception",
+
+      # Generic - these will be put in a `Types::Raw`, so writing RBS syntax is a little devious,
+      # but by their nature we know they'll only be used in an RBS file, so it's probably fine
+      "#to_hash" => "_ToHash[untyped, untyped]",
+      "#each" => "_Each[untyped]",
     }
 
     # Given a YARD duck type string, attempts to convert it to one of a list of pre-defined RBS

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -320,5 +320,28 @@ describe Sord::TypeConverter do
         expect(yard_to_parlour_default('Hash<Array>')).to eq Types::Raw.new('SORD_ERROR_Arrayuntyped')
       end
     end
+
+    context 'when using RBS' do
+      let :config do
+        Sord::TypeConverter::Configuration.new(
+          output_language: :rbs,
+          replace_errors_with_untyped: false,
+          replace_unresolved_with_untyped: false,  
+        )
+      end
+
+      it 'replaces known duck types with built-in interfaces' do
+        # Converts known types
+        expect(subject.yard_to_parlour('#to_s', nil, config)).to eq Types::Raw.new('_ToS')
+        expect(subject.yard_to_parlour('#to_i', nil, config)).to eq Types::Raw.new('_ToI')
+        expect(subject.yard_to_parlour('#write', nil, config)).to eq Types::Raw.new('_Writer')
+
+        # Doesn't convert unknown types
+        expect(subject.yard_to_parlour('#foobar', nil, config)).to eq Types::Untyped.new
+
+        # Doesn't affect RBI, where these interfaces don't exist
+        expect(yard_to_parlour_default('#to_s')).to eq Types::Untyped.new
+      end
+    end
   end
 end

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -335,6 +335,7 @@ describe Sord::TypeConverter do
         expect(subject.yard_to_parlour('#to_s', nil, config)).to eq Types::Raw.new('_ToS')
         expect(subject.yard_to_parlour('#to_i', nil, config)).to eq Types::Raw.new('_ToI')
         expect(subject.yard_to_parlour('#write', nil, config)).to eq Types::Raw.new('_Writer')
+        expect(subject.yard_to_parlour('#to_hash', nil, config)).to eq Types::Raw.new('_ToHash[untyped, untyped]')
 
         # Doesn't convert unknown types
         expect(subject.yard_to_parlour('#foobar', nil, config)).to eq Types::Untyped.new

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -7,88 +7,100 @@ describe Sord::TypeConverter do
   end
 
   describe '#yard_to_parlour' do
+    def default_config
+      Sord::TypeConverter::Configuration.new(
+        output_language: :rbi,
+        replace_errors_with_untyped: false,
+        replace_unresolved_with_untyped: false,
+      )
+    end
+
+    def yard_to_parlour_default(type)
+      subject.yard_to_parlour(type, nil, default_config)
+    end
+
     context 'when given nil' do
       it 'assigns untyped to missing types' do
-        expect(subject.yard_to_parlour(nil)).to eq Types::Untyped.new
+        expect(yard_to_parlour_default(nil)).to eq Types::Untyped.new
       end
     end
 
     context 'with String' do
       it 'returns it without logs if it is simple and a namespace/class' do
-        expect(subject.yard_to_parlour('String')).to eq Types::Raw.new('String')
-        expect(subject.yard_to_parlour('::Kernel::Array')).to eq Types::Raw.new('::Kernel::Array')
+        expect(yard_to_parlour_default('String')).to eq Types::Raw.new('String')
+        expect(yard_to_parlour_default('::Kernel::Array')).to eq Types::Raw.new('::Kernel::Array')
       end
 
       it 'returns it with a warning if it looks like a non-namespace' do
         expect {
-          expect(subject.yard_to_parlour('foo')).to eq Types::Raw.new('foo')
+          expect(yard_to_parlour_default('foo')).to eq Types::Raw.new('foo')
         }.to log :warn
       end
 
       it 'can handle empty strings' do
         expect {
-          expect(subject.yard_to_parlour('')).to eq Types::Raw.new('SORD_ERROR_')
+          expect(yard_to_parlour_default('')).to eq Types::Raw.new('SORD_ERROR_')
         }.to log :warn
       end
     end
 
     context 'with Boolean' do
       it 'coerces \'boolean\' and its variants' do
-        expect(subject.yard_to_parlour('bool')).to eq Types::Boolean.new
-        expect(subject.yard_to_parlour('Boolean')).to eq Types::Boolean.new
+        expect(yard_to_parlour_default('bool')).to eq Types::Boolean.new
+        expect(yard_to_parlour_default('Boolean')).to eq Types::Boolean.new
       end
 
       it 'coerces boolean literals' do
-        expect(subject.yard_to_parlour('true')).to eq Types::Boolean.new
-        expect(subject.yard_to_parlour('false')).to eq Types::Boolean.new
-        expect(subject.yard_to_parlour(['true', 'false'])).to eq \
+        expect(yard_to_parlour_default('true')).to eq Types::Boolean.new
+        expect(yard_to_parlour_default('false')).to eq Types::Boolean.new
+        expect(yard_to_parlour_default(['true', 'false'])).to eq \
           Types::Boolean.new
       end
     end
 
     context 'with multiple types' do
       it 'unwraps it if it contains one item' do
-        expect(subject.yard_to_parlour(['String'])).to eq Types::Raw.new('String')
+        expect(yard_to_parlour_default(['String'])).to eq Types::Raw.new('String')
       end
 
       it 'forms a T.any if it contains more than one item' do
-        expect(subject.yard_to_parlour(['String', 'Integer'])).to eq Types::Union.new(['String', 'Integer'])
+        expect(yard_to_parlour_default(['String', 'Integer'])).to eq Types::Union.new(['String', 'Integer'])
       end
 
       it 'converts types with nil to nilable' do
-        expect(subject.yard_to_parlour(['String', 'Integer', 'nil'])).to eq \
+        expect(yard_to_parlour_default(['String', 'Integer', 'nil'])).to eq \
           Types::Nilable.new(Types::Union.new(['String', 'Integer']))
-        expect(subject.yard_to_parlour(['String', 'nil'])).to eq \
+        expect(yard_to_parlour_default(['String', 'nil'])).to eq \
           Types::Nilable.new('String')
       end
     end
 
     context 'with literals' do
       it 'converts literals to their types' do
-        expect(subject.yard_to_parlour([':up', ':down'])).to eq Types::Raw.new('Symbol')
-        expect(subject.yard_to_parlour(['String', ':up', ':down'])).to eq \
+        expect(yard_to_parlour_default([':up', ':down'])).to eq Types::Raw.new('Symbol')
+        expect(yard_to_parlour_default(['String', ':up', ':down'])).to eq \
           Types::Union.new(['String', 'Symbol'])
-        expect(subject.yard_to_parlour('3')).to eq Types::Raw.new('Integer')
-        expect(subject.yard_to_parlour('3.14')).to eq Types::Raw.new('Float')
-        # expect(subject.yard_to_parlour('\'foo\'')).to eq 'String'
+        expect(yard_to_parlour_default('3')).to eq Types::Raw.new('Integer')
+        expect(yard_to_parlour_default('3.14')).to eq Types::Raw.new('Float')
+        # expect(yard_to_parlour_default('\'foo\'')).to eq 'String'
       end
     end
 
     context 'with duck types' do
       it 'converts duck types to T.untyped' do
-        expect(subject.yard_to_parlour('#to_s')).to eq Types::Untyped.new
-        expect(subject.yard_to_parlour('#setter=')).to eq Types::Untyped.new
-        expect(subject.yard_to_parlour('#foo & #bar')).to eq Types::Untyped.new
-        expect(subject.yard_to_parlour('#foo & #foo_bar & #baz')).to eq Types::Untyped.new
-        expect(subject.yard_to_parlour('#foo&#bar')).to eq Types::Untyped.new
-        expect(subject.yard_to_parlour('#foo & #setter=')).to eq Types::Untyped.new
-        expect(subject.yard_to_parlour('#foo!')).to eq Types::Untyped.new
-        expect(subject.yard_to_parlour('#===')).to eq Types::Untyped.new
-        expect(subject.yard_to_parlour('#=== & #[]= & #!~')).to eq Types::Untyped.new
+        expect(yard_to_parlour_default('#to_s')).to eq Types::Untyped.new
+        expect(yard_to_parlour_default('#setter=')).to eq Types::Untyped.new
+        expect(yard_to_parlour_default('#foo & #bar')).to eq Types::Untyped.new
+        expect(yard_to_parlour_default('#foo & #foo_bar & #baz')).to eq Types::Untyped.new
+        expect(yard_to_parlour_default('#foo&#bar')).to eq Types::Untyped.new
+        expect(yard_to_parlour_default('#foo & #setter=')).to eq Types::Untyped.new
+        expect(yard_to_parlour_default('#foo!')).to eq Types::Untyped.new
+        expect(yard_to_parlour_default('#===')).to eq Types::Untyped.new
+        expect(yard_to_parlour_default('#=== & #[]= & #!~')).to eq Types::Untyped.new
       end
 
       it 'does not convert invalid duck types' do
-        expect(subject.yard_to_parlour('#foo&bar')).to eq Types::Raw.new('SORD_ERROR_foobar')
+        expect(yard_to_parlour_default('#foo&bar')).to eq Types::Raw.new('SORD_ERROR_foobar')
       end
     end
 
@@ -105,28 +117,28 @@ describe Sord::TypeConverter do
           end
         end
 
-        expect(subject.yard_to_parlour('self', stub_method)).to eq Types::Self.new
+        expect(subject.yard_to_parlour('self', stub_method, default_config)).to eq Types::Self.new
       end
     end
 
     context 'with type parameters' do
       it 'handles correctly-formed one-argument type parameters' do
-        expect(subject.yard_to_parlour('Array<String>')).to eq Types::Array.new('String')
-        expect(subject.yard_to_parlour('Set<String>')).to eq Types::Set.new('String')
+        expect(yard_to_parlour_default('Array<String>')).to eq Types::Array.new('String')
+        expect(yard_to_parlour_default('Set<String>')).to eq Types::Set.new('String')
       end
 
       it 'uses T.any if multiple arguments are specified to a one-argument type parameter' do
-        expect(subject.yard_to_parlour('Array<String, Integer>')).to eq \
+        expect(yard_to_parlour_default('Array<String, Integer>')).to eq \
           Types::Array.new(Types::Union.new(['String', 'Integer']))
       end
 
       it 'handles whitespace' do
-        expect(subject.yard_to_parlour('Array < String >')).to eq Types::Array.new('String')
+        expect(yard_to_parlour_default('Array < String >')).to eq Types::Array.new('String')
       end
 
       it 'handles correctly-formed two-argument type parameters' do
-        expect(subject.yard_to_parlour('Hash<String, Integer>')).to eq Types::Hash.new('String', 'Integer')
-        expect(subject.yard_to_parlour('Hash<Hash<String, Symbol>, Hash<Array<Symbol>, Integer>>')).to eq \
+        expect(yard_to_parlour_default('Hash<String, Integer>')).to eq Types::Hash.new('String', 'Integer')
+        expect(yard_to_parlour_default('Hash<Hash<String, Symbol>, Hash<Array<Symbol>, Integer>>')).to eq \
           Types::Hash.new(
             Types::Hash.new('String', 'Symbol'),
             Types::Hash.new(Types::Array.new('Symbol'), 'Integer')
@@ -134,15 +146,15 @@ describe Sord::TypeConverter do
       end
 
       it 'handles correctly-formed two-argument type parameters with hash rockets' do
-        expect(subject.yard_to_parlour('Hash<String=>Symbol>')).to eq Types::Hash.new('String', 'Symbol')
-        expect(subject.yard_to_parlour('Hash{String=>Symbol}')).to eq Types::Hash.new('String', 'Symbol')
-        expect(subject.yard_to_parlour('Hash{String => Symbol}')).to eq Types::Hash.new('String', 'Symbol')
-        expect(subject.yard_to_parlour('Hash<Hash{String => Symbol}, Hash<Array<Symbol>, Integer>>')).to eq \
+        expect(yard_to_parlour_default('Hash<String=>Symbol>')).to eq Types::Hash.new('String', 'Symbol')
+        expect(yard_to_parlour_default('Hash{String=>Symbol}')).to eq Types::Hash.new('String', 'Symbol')
+        expect(yard_to_parlour_default('Hash{String => Symbol}')).to eq Types::Hash.new('String', 'Symbol')
+        expect(yard_to_parlour_default('Hash<Hash{String => Symbol}, Hash<Array<Symbol>, Integer>>')).to eq \
           Types::Hash.new(
             Types::Hash.new('String', 'Symbol'),
             Types::Hash.new(Types::Array.new('Symbol'), 'Integer')
           )
-        expect(subject.yard_to_parlour('Hash{Hash{String => Symbol} => Hash{Array<Symbol> => Integer}}')).to eq \
+        expect(yard_to_parlour_default('Hash{Hash{String => Symbol} => Hash{Array<Symbol> => Integer}}')).to eq \
           Types::Hash.new(
             Types::Hash.new('String', 'Symbol'),
             Types::Hash.new(Types::Array.new('Symbol'), 'Integer')
@@ -150,32 +162,32 @@ describe Sord::TypeConverter do
       end
 
       it 'handles order-dependent lists by returning Tuples' do
-        expect(subject.yard_to_parlour('Array(String, Integer)')).to eq Types::Tuple.new(['String', 'Integer'])
-        expect(subject.yard_to_parlour('Array(Integer, Integer)')).to eq Types::Tuple.new(['Integer', 'Integer'])
-        expect(subject.yard_to_parlour('Array(Fixnum, String, Symbol, Integer)')).to eq \
+        expect(yard_to_parlour_default('Array(String, Integer)')).to eq Types::Tuple.new(['String', 'Integer'])
+        expect(yard_to_parlour_default('Array(Integer, Integer)')).to eq Types::Tuple.new(['Integer', 'Integer'])
+        expect(yard_to_parlour_default('Array(Fixnum, String, Symbol, Integer)')).to eq \
           Types::Tuple.new(['Fixnum', 'String', 'Symbol', 'Integer'])
-        expect(subject.yard_to_parlour('(String, Integer)')).to eq \
+        expect(yard_to_parlour_default('(String, Integer)')).to eq \
           Types::Tuple.new(['String', 'Integer'])
       end
 
       it 'handles nested order-dependent lists by returning nested Tuples' do
-        expect(subject.yard_to_parlour('(String, Symbol, Array(String, Symbol))')).to eq \
+        expect(yard_to_parlour_default('(String, Symbol, Array(String, Symbol))')).to eq \
           Types::Tuple.new(['String', 'Symbol', Types::Tuple.new(['String', 'Symbol'])])
-        expect(subject.yard_to_parlour('(String, Symbol, (String, Symbol))')).to eq \
+        expect(yard_to_parlour_default('(String, Symbol, (String, Symbol))')).to eq \
           Types::Tuple.new(['String', 'Symbol', Types::Tuple.new(['String', 'Symbol'])])
       end
 
       it 'handles shorthand Hash syntax' do
-        expect(subject.yard_to_parlour('{String => Symbol}')).to eq Types::Hash.new('String', 'Symbol')
-        expect(subject.yard_to_parlour('{{String => Integer} => {Symbol => Float}}')).to eq \
+        expect(yard_to_parlour_default('{String => Symbol}')).to eq Types::Hash.new('String', 'Symbol')
+        expect(yard_to_parlour_default('{{String => Integer} => {Symbol => Float}}')).to eq \
           Types::Hash.new(Types::Hash.new('String', 'Integer'), Types::Hash.new('Symbol', 'Float'))
-        expect(subject.yard_to_parlour('{{String, Integer}, {Symbol, Float}}')).to eq \
+        expect(yard_to_parlour_default('{{String, Integer}, {Symbol, Float}}')).to eq \
           Types::Hash.new(Types::Hash.new('String', 'Integer'), Types::Hash.new('Symbol', 'Float'))
       end
 
       it 'handles shorthand Array syntax' do
-        expect(subject.yard_to_parlour('<String>')).to eq Types::Array.new('String')
-        expect(subject.yard_to_parlour('<String, <Boolean, Symbol>>')).to eq \
+        expect(yard_to_parlour_default('<String>')).to eq Types::Array.new('String')
+        expect(yard_to_parlour_default('<String, <Boolean, Symbol>>')).to eq \
           Types::Array.new(
             Types::Union.new([
               'String', Types::Array.new(
@@ -186,12 +198,12 @@ describe Sord::TypeConverter do
       end
 
       it 'converts Class types' do
-        expect(subject.yard_to_parlour('Class<String>')).to eq Types::Class.new('String')
+        expect(yard_to_parlour_default('Class<String>')).to eq Types::Class.new('String')
       end
 
       context 'with user defined generic' do
         it 'handles single parameter' do
-          expect(subject.yard_to_parlour('Wrapper<String>')).to eq \
+          expect(yard_to_parlour_default('Wrapper<String>')).to eq \
             Types::Generic.new(
               Types::Raw.new('Wrapper'),
               [Types::Raw.new('String')]
@@ -199,7 +211,7 @@ describe Sord::TypeConverter do
         end
 
         it 'handles multiple parameter' do
-          expect(subject.yard_to_parlour('Mapper<String, Integer>')).to eq \
+          expect(yard_to_parlour_default('Mapper<String, Integer>')).to eq \
             Types::Generic.new(
               Types::Raw.new('Mapper'),
               [Types::Raw.new('String'), Types::Raw.new('Integer')]
@@ -207,7 +219,7 @@ describe Sord::TypeConverter do
         end
 
         it 'handles nested parameters' do
-          expect(subject.yard_to_parlour('Wrapper<Wrapper<String>>')).to eq \
+          expect(yard_to_parlour_default('Wrapper<Wrapper<String>>')).to eq \
             Types::Generic.new(
               Types::Raw.new('Wrapper'),
               [
@@ -221,77 +233,91 @@ describe Sord::TypeConverter do
       end
 
       it 'does not resolve stdlib objects instead of types when using the root namespace' do
-        expect(subject.yard_to_parlour('::Array<String>')).to eq Types::Array.new('String')
+        expect(yard_to_parlour_default('::Array<String>')).to eq Types::Array.new('String')
       end
     end
 
     context 'when given an untyped generic' do
       it 'handles Hash correctly' do
-        expect(subject.yard_to_parlour('Hash')).to eq Types::Hash.new(Types::Untyped.new, Types::Untyped.new)
+        expect(yard_to_parlour_default('Hash')).to eq Types::Hash.new(Types::Untyped.new, Types::Untyped.new)
       end
 
       it 'handles Array correctly' do
-        expect(subject.yard_to_parlour('Array')).to eq Types::Array.new(Types::Untyped.new)
+        expect(yard_to_parlour_default('Array')).to eq Types::Array.new(Types::Untyped.new)
       end
 
       it 'handles Range correctly' do
-        expect(subject.yard_to_parlour('Range')).to eq Types::Range.new(Types::Untyped.new)
+        expect(yard_to_parlour_default('Range')).to eq Types::Range.new(Types::Untyped.new)
       end
 
       it 'handles Set correctly' do
-        expect(subject.yard_to_parlour('Set')).to eq Types::Set.new(Types::Untyped.new)
+        expect(yard_to_parlour_default('Set')).to eq Types::Set.new(Types::Untyped.new)
       end
 
       it 'handles Enumerable correctly' do
-        expect(subject.yard_to_parlour('Enumerable')).to eq Types::Enumerable.new(Types::Untyped.new)
+        expect(yard_to_parlour_default('Enumerable')).to eq Types::Enumerable.new(Types::Untyped.new)
       end
 
       it 'handles Enumerator correctly' do
-        expect(subject.yard_to_parlour('Enumerator')).to eq Types::Enumerator.new(Types::Untyped.new)
+        expect(yard_to_parlour_default('Enumerator')).to eq Types::Enumerator.new(Types::Untyped.new)
       end
     end
 
     context 'invalid YARD docs' do
       it 'SORD_ERROR for invalid duck types' do
-        expect(subject.yard_to_parlour('foo&bar')).to eq Types::Raw.new('SORD_ERROR_foobar')
-        expect(subject.yard_to_parlour('foo&#bar')).to eq Types::Raw.new('SORD_ERROR_foobar')
-        expect(subject.yard_to_parlour('#foo&bar')).to eq Types::Raw.new('SORD_ERROR_foobar')
-        expect(subject.yard_to_parlour('#foo-bar')).to eq Types::Raw.new('SORD_ERROR_foobar')
-        expect(subject.yard_to_parlour('#=foobar')).to eq Types::Raw.new('SORD_ERROR_foobar')
+        expect(yard_to_parlour_default('foo&bar')).to eq Types::Raw.new('SORD_ERROR_foobar')
+        expect(yard_to_parlour_default('foo&#bar')).to eq Types::Raw.new('SORD_ERROR_foobar')
+        expect(yard_to_parlour_default('#foo&bar')).to eq Types::Raw.new('SORD_ERROR_foobar')
+        expect(yard_to_parlour_default('#foo-bar')).to eq Types::Raw.new('SORD_ERROR_foobar')
+        expect(yard_to_parlour_default('#=foobar')).to eq Types::Raw.new('SORD_ERROR_foobar')
       end
 
       it 'SORD_ERROR for invalid hashes with uneven curly braces' do
-        expect(subject.yard_to_parlour('Hash{String, Symbol')).to eq Types::Raw.new('SORD_ERROR_HashStringSymbol')
-        expect(subject.yard_to_parlour('Hash{String')).to eq Types::Raw.new('SORD_ERROR_HashString')
+        expect(yard_to_parlour_default('Hash{String, Symbol')).to eq Types::Raw.new('SORD_ERROR_HashStringSymbol')
+        expect(yard_to_parlour_default('Hash{String')).to eq Types::Raw.new('SORD_ERROR_HashString')
       end
 
       it 'SORD_ERROR for invalid Arrays with uneven angle brackets' do
-        expect(subject.yard_to_parlour('Array<String, Symbol')).to eq Types::Raw.new('SORD_ERROR_ArrayStringSymbol')
-        expect(subject.yard_to_parlour('Array<String')).to eq Types::Raw.new('SORD_ERROR_ArrayString')
+        expect(yard_to_parlour_default('Array<String, Symbol')).to eq Types::Raw.new('SORD_ERROR_ArrayStringSymbol')
+        expect(yard_to_parlour_default('Array<String')).to eq Types::Raw.new('SORD_ERROR_ArrayString')
       end
 
       it 'SORD_ERROR for a type list not inside a container' do
-        expect(subject.yard_to_parlour('String, Symbol')).to eq Types::Raw.new('SORD_ERROR_StringSymbol')
+        expect(yard_to_parlour_default('String, Symbol')).to eq Types::Raw.new('SORD_ERROR_StringSymbol')
       end
 
       it 'T.untyped rather than SORD_ERROR if option is set' do
-        expect(subject.yard_to_parlour('Hash{String, Symbol', nil, true)).to eq Types::Untyped.new
+        expect(subject.yard_to_parlour(
+          'Hash{String, Symbol', nil,
+          Sord::TypeConverter::Configuration.new(
+            output_language: :rbi,
+            replace_errors_with_untyped: true,
+            replace_unresolved_with_untyped: true,
+          )
+        )).to eq Types::Untyped.new
       end
 
       it 'T.untyped rather than unresolved constant if option is set' do
-        expect(subject.yard_to_parlour('TestConstantThatDoesNotExist', YARD::CodeObjects::NamespaceObject.new(:root, :Foo), false, true)).to eq Types::Untyped.new
+        expect(subject.yard_to_parlour(
+          'TestConstantThatDoesNotExist', YARD::CodeObjects::NamespaceObject.new(:root, :Foo),
+          Sord::TypeConverter::Configuration.new(
+            output_language: :rbi,
+            replace_errors_with_untyped: false,
+            replace_unresolved_with_untyped: true,
+          )
+        )).to eq Types::Untyped.new
       end
 
       it 'SORD_ERROR for a hash with too many parameters' do
-        expect(subject.yard_to_parlour('{Integer, Integer, Integer}')).to eq Types::Raw.new('SORD_ERROR_IntegerIntegerInteger')
+        expect(yard_to_parlour_default('{Integer, Integer, Integer}')).to eq Types::Raw.new('SORD_ERROR_IntegerIntegerInteger')
       end
 
       it 'SORD_ERROR for a hash with too few parameters' do
-        expect(subject.yard_to_parlour('{Integer}')).to eq Types::Raw.new('SORD_ERROR_Integer')
+        expect(yard_to_parlour_default('{Integer}')).to eq Types::Raw.new('SORD_ERROR_Integer')
       end
 
       it 'SORD_ERROR for a hash with too few parameters' do
-        expect(subject.yard_to_parlour('Hash<Array>')).to eq Types::Raw.new('SORD_ERROR_Arrayuntyped')
+        expect(yard_to_parlour_default('Hash<Array>')).to eq Types::Raw.new('SORD_ERROR_Arrayuntyped')
       end
     end
   end


### PR DESCRIPTION
If you're converting to RBS, some duck types like `#to_s` now get converted to their RBS interfaces like `_ToS`.

Also took this opportunity to refactor the way configuration gets passed to `TypeConverter` to make it easier to add more configuration. (Previously `TypeConverter` wasn't aware of the output type language.)

Fixes #154