### PR TITLE
Fix seeded examples

### DIFF
--- a/lib/sord/generator.rb
+++ b/lib/sord/generator.rb
@@ -319,9 +319,9 @@ module Sord
               yieldreturn&.first&.downcase == 'void'
 
             # Create strings
-            params = yieldparams.map do |param|
+            params = yieldparams.map.with_index do |param, i|
               Parlour::Types::Proc::Parameter.new(
-                param.name.gsub('*', ''),
+                param.name&.gsub('*', '') || "arg#{i}",
                 TypeConverter.yard_to_parlour(param.types, meth, @replace_errors_with_untyped, @replace_unresolved_with_untyped)
               )
             end

--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -183,7 +183,7 @@ module Sord
             handle_sord_error(parameters.map(&:describe).join, "Invalid hash, must have exactly two types: #{yard.inspect}.", item, replace_errors_with_untyped)
           end
         else
-          if Parlour::Types.const_defined?(relative_generic_type)
+          if Parlour::Types.constants.include?(relative_generic_type.to_sym)
             # This generic is built in to parlour, but sord doesn't
             # explicitly know about it.
             Parlour::Types.const_get(relative_generic_type).new(*parameters)

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -523,6 +523,32 @@ describe Sord::Generator do
     RUBY
   end
 
+  it 'handles missing block parameter names' do
+    YARD.parse_string(<<-RUBY)
+      module A
+        # @yieldparam [Symbol]
+        # @yieldparam [String]
+        # @yieldreturn [void]
+        # @return [void]
+        def self.foo(&blk); end
+      end
+    RUBY
+
+    expect(rbi_gen.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      module A
+        sig { params(blk: T.proc.params(arg0: Symbol, arg1: String).void).void }
+        def self.foo(&blk); end
+      end
+    RUBY
+
+    expect(rbs_gen.generate.strip).to eq fix_heredoc(<<-RUBY)
+      module A
+        def self.foo: () ?{ (Symbol arg0, String arg1) -> void } -> void
+      end
+    RUBY
+  end
+
   it 'handle multiline comment correctly' do
     YARD.parse_string(<<-RUBY)
       module A


### PR DESCRIPTION
Fixes a couple of issues which caused fatal errors when building the examples:

- Blocks with missing parameters caused an exception. Now these use a set of default names (`arg0`, `arg1`, ...)
- Dynamic name resolution of built-in Parlour types was picking up kernel modules like `Class`, and trying to instantiate them and treat them as types. The name resolution is now stricter.