### PR TITLE
Support single overload

### DIFF
--- a/lib/sord/generator.rb
+++ b/lib/sord/generator.rb
@@ -294,6 +294,13 @@ module Sord
           next
         end
 
+        # If the method has YARD's @overload tags, use the information
+        # of the first one
+        # NOTE: This code does not handle the second and subsequent @overload tags
+        if !meth.tags("overload").empty?
+          meth = meth.tags("overload").first
+        end
+        
         # Sort parameters
         meth.parameters.reverse.sort! { |pair1, pair2| sort_params(pair1, pair2) }
 

--- a/lib/sord/generator.rb
+++ b/lib/sord/generator.rb
@@ -294,11 +294,13 @@ module Sord
           next
         end
 
-        # If the method has YARD's @overload tags, use the information
-        # of the first one
+        # If the method has YARD's "@overload" tags, the information of the
+        # first one is merged into meth object
         # NOTE: This code does not handle the second and subsequent @overload tags
-        if !meth.tags("overload").empty?
-          meth = meth.tags("overload").first
+        if meth.tag("overload")
+          meth.parameters = meth.tag("overload").parameters
+          meth.tag("overload").tags.each { |tag| meth.add_tag(tag) }
+          meth.docstring += meth.tag("overload").docstring
         end
         
         # Sort parameters

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -2040,4 +2040,34 @@ describe Sord::Generator do
       end
     RUBY
   end
+
+  it 'works with YARD\'s overload tag with toplevel return tag' do
+    YARD.parse_string(<<-RUBY)
+      class A
+        # Comment for method x
+        # @overload x(a, b)
+        #   Overload comment
+        #   @param a [String]
+        #   @param b [Integer]
+        # @return [Integer] example integer
+        def x(*args); end
+      end
+    RUBY
+
+    expect(rbi_gen.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      class A
+        # Comment for method x
+        # Overload comment
+        # 
+        # _@param_ `a`
+        # 
+        # _@param_ `b`
+        # 
+        # _@return_ — example integer
+        sig { params(a: String, b: Integer).returns(Integer) }
+        def x(a, b); end
+      end
+    RUBY
+  end
 end

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -2017,4 +2017,27 @@ describe Sord::Generator do
       end
     RUBY
   end
+
+  it 'works with YARD\'s overload tag' do
+    YARD.parse_string(<<-RUBY)
+      class A
+        # @overload x(a, b)
+        #   @param a [String]
+        #   @param b [Integer]
+        #   @return [void]
+        def x(*args); end
+      end
+    RUBY
+
+    expect(rbi_gen.generate.strip).to eq fix_heredoc(<<-RUBY)
+      # typed: strong
+      class A
+        # _@param_ `a`
+        # 
+        # _@param_ `b`
+        sig { params(a: String, b: Integer).void }
+        def x(a, b); end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
# Outline

This PR adds support for a single "overload" tag.  This PR is required to handle YARD documents for C/C++ extension.

# Background
The "overload" tag in YARD is used for the following two purposes:

1. Describing overloaded methods
2. Write YARD documents for C/C++ extensions

The YARD system can not retrieve signatures of methods written by C/C++, therefore overload tag is usually used to describe such method signatures.

# Description 

This PR treats such an overload tag by replacing the method signature with the content of the first overload tag. 
The information contained in the overload tag is also merged into the method object.

# Limitation

The second and subsequent overload tags are ignored.
