### PR TITLE
Read local RBI files when parsing

### DIFF
--- a/lib/sord/resolver.rb
+++ b/lib/sord/resolver.rb
@@ -30,7 +30,7 @@ module Sord
       end
       add_rbs_objects_to_paths(env, hash)
 
-      gem_paths = Bundler.load.specs.map(&:full_gem_path)
+      gem_paths = Bundler.load.specs.map(&:full_gem_path) + ["#{Dir.pwd}/sorbet"]
       gem_paths.each do |path|
         next unless File.exist?("#{path}/rbi")
 


### PR DESCRIPTION
This update adds the local `sorbet` directory to `sord`'s list. Most gems don't have actual `rbi` directories in them - instead a lot of them depend on `sorbet-typed`. Using `tapioca` will dump a bunch of RBI files into a local `sorbet` directory, which `sord` can then read and use as types inside type declarations.

This does take a bit of time (the default is to actually generate types for every single gem that's included, which is likely overkill since very few of them would be directly referenced in the project code). Not sure if we want to print out some kind of message when we parse this directory indicating that the user might want to delete some of those auto-generated files to speed up the process.