### PR TITLE
Support Class with multiple parameters as union type of class types

### DIFF
--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -197,8 +197,12 @@ module Sord
           .map { |x| yard_to_parlour(x, item, config) }
         if SINGLE_ARG_GENERIC_TYPES.include?(relative_generic_type) && parameters.length > 1
           Parlour::Types.const_get(relative_generic_type).new(Parlour::Types::Union.new(parameters))
-        elsif relative_generic_type == 'Class' && parameters.length == 1
-          Parlour::Types::Class.new(parameters.first)
+        elsif relative_generic_type == 'Class'
+          if parameters.length == 1
+            Parlour::Types::Class.new(parameters.first)
+          else
+            Parlour::Types::Union.new(parameters.map { |x| Parlour::Types::Class.new(x) })
+          end
         elsif relative_generic_type == 'Hash'
           if parameters.length == 2
             Parlour::Types::Hash.new(*parameters)

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -201,6 +201,14 @@ describe Sord::TypeConverter do
         expect(yard_to_parlour_default('Class<String>')).to eq Types::Class.new('String')
       end
 
+      pending 'converts Class types with multiple parameters' do
+        expect(yard_to_parlour_default('Class<String, Integer>')).to eq \
+          Types::Union.new([
+            Types::Class.new('String'),
+            Types::Class.new('Integer'),
+          ])
+      end
+
       context 'with user defined generic' do
         it 'handles single parameter' do
           expect(yard_to_parlour_default('Wrapper<String>')).to eq \

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -201,7 +201,7 @@ describe Sord::TypeConverter do
         expect(yard_to_parlour_default('Class<String>')).to eq Types::Class.new('String')
       end
 
-      pending 'converts Class types with multiple parameters' do
+      it 'converts Class types with multiple parameters' do
         expect(yard_to_parlour_default('Class<String, Integer>')).to eq \
           Types::Union.new([
             Types::Class.new('String'),


### PR DESCRIPTION
For now, when sord sees the type `Class<String, Integer>`, sord crashes with the following error.

```
     Failure/Error: Parlour::Types.const_get(relative_generic_type).new(*parameters)

     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # ~/.anyenv/envs/rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/sorbet-runtime-0.5.10950/lib/types/private/methods/call_validation_2_7.rb:1000:in `block in create_validator_procedure_medium1'
     # ~/.anyenv/envs/rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/sorbet-runtime-0.5.10950/lib/types/private/abstract/declare.rb:38:in `new'
     # ~/.anyenv/envs/rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/sorbet-runtime-0.5.10950/lib/types/private/abstract/declare.rb:38:in `block in declare_abstract'
     # ./lib/sord/type_converter.rb:212:in `yard_to_parlour'
```

(The error means [Parlour::Types::Class.new](https://github.com/AaronC81/parlour/blob/8.1.0/lib/parlour/types.rb#L406) only accepts 1 parameter.)

With this PR, sord avoids the error and considers the type as union of class types.
