### PR TITLE
Fix the type signature with circular inheritance

### DIFF
--- a/lib/sord/generator.rb
+++ b/lib/sord/generator.rb
@@ -582,8 +582,10 @@ module Sord
       return if @hide_private && item.visibility == :private
       count_namespace
 
-      superclass = nil
-      superclass = item.superclass.path.to_s if item.type == :class && item.superclass.to_s != "Object"
+      if item.type == :class && item.superclass.to_s != "Object"
+        prefix = "::" if item.name.to_s == item.superclass.path
+        superclass = "#{prefix}#{item.superclass.path}"
+      end
 
       parent = @current_object
       @current_object = item.type == :class \

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -2070,4 +2070,26 @@ describe Sord::Generator do
       end
     RUBY
   end
+
+  it 'works even if the parent class has the same name' do
+    YARD.parse_string(<<-RUBY)
+      class X
+      end
+
+      module M
+        class X < ::X
+        end
+      end
+    RUBY
+
+    expect(rbs_gen.generate.strip).to eq fix_heredoc(<<-RUBY)
+      class X
+      end
+
+      module M
+        class X < ::X
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
If you define a class with the same name as the parent class, sord will generate the type signature with circular inheritance.
For example, the code is as follows.

```ruby
class ApplicationRecord
end

module Api
  class ApplicationRecord < ::ApplicationRecord
  end
end
```

This commit adds a name separator when needed and fixes the type signature so that it is not circular.
