### PR TITLE
Fix generation of heredoc bodies in RBI files for constants

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [2.7, 3.0, 3.1]
+        ruby: [3.0, 3.1]
     continue-on-error: false
 
     runs-on: ubuntu-latest

--- a/sord.gemspec
+++ b/sord.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sorbet-runtime'
   spec.add_dependency 'commander', '~> 5.0'
   spec.add_dependency "parser"
-  spec.add_dependency 'parlour', '~> 9.0'
+  spec.add_dependency 'parlour', '~> 9.1'
   spec.add_dependency 'rbs', '~> 3.0'
 
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/sord.gemspec
+++ b/sord.gemspec
@@ -24,8 +24,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'yard'
   spec.add_dependency 'sorbet-runtime'
-  spec.add_dependency 'commander', '~> 4.5'
-  spec.add_dependency 'parlour', '~> 5.0'
+  spec.add_dependency 'commander', '~> 5.0'
+  spec.add_dependency "parser"
+  spec.add_dependency 'parlour', '~> 9.0'
   spec.add_dependency 'rbs', '~> 3.0'
 
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -1117,6 +1117,13 @@ describe Sord::Generator do
         EXAMPLE_UNTYPED_CONSTANT = 'Foo'
         # @return [String]
         EXAMPLE_TYPED_CONSTANT = 'Bar'
+        EXAMPLE_UNTYPED_CONSTANT_WITH_HEREDOC = <<END
+Baz
+END
+        # @return [String]
+        EXAMPLE_TYPED_CONSTANT_WITH_HEREDOC = <<END
+Bing
+END
       end
     RUBY
 
@@ -1125,6 +1132,12 @@ describe Sord::Generator do
       class A
         EXAMPLE_UNTYPED_CONSTANT = T.let('Foo', T.untyped)
         EXAMPLE_TYPED_CONSTANT = T.let('Bar', T.untyped)
+        EXAMPLE_UNTYPED_CONSTANT_WITH_HEREDOC = T.let(<<END, T.untyped)
+Baz
+END
+        EXAMPLE_TYPED_CONSTANT_WITH_HEREDOC = T.let(<<END, T.untyped)
+Bing
+END
       end
     RUBY
 
@@ -1132,6 +1145,8 @@ describe Sord::Generator do
       class A
         EXAMPLE_UNTYPED_CONSTANT: untyped
         EXAMPLE_TYPED_CONSTANT: String
+        EXAMPLE_UNTYPED_CONSTANT_WITH_HEREDOC: untyped
+        EXAMPLE_TYPED_CONSTANT_WITH_HEREDOC: String
       end
     RUBY
   end


### PR DESCRIPTION
This is the corresponding change to
https://github.com/AaronC81/parlour/pull/145 to parse heredocs out of yard output and use the information to avoid generating invalid RBI files.

This isn't an issue for RBS, which does not include the constant values.