### PR TITLE
Correctly parse Array<T, nil> and friends

### DIFF
--- a/lib/sord/type_converter.rb
+++ b/lib/sord/type_converter.rb
@@ -193,8 +193,10 @@ module Sord
         relative_generic_type = generic_type.start_with?('::') \
           ? generic_type[2..-1] : generic_type
 
-        parameters = split_type_parameters(type_parameters)
-          .map { |x| yard_to_parlour(x, item, config) }
+        parameters_type = yard_to_parlour(split_type_parameters(type_parameters),
+                                          item, config)
+        parameters = parameters_type.is_a?(Parlour::Types::Union) ? parameters_type.types : [parameters_type]
+
         if SINGLE_ARG_GENERIC_TYPES.include?(relative_generic_type) && parameters.length > 1
           Parlour::Types.const_get(relative_generic_type).new(Parlour::Types::Union.new(parameters))
         elsif relative_generic_type == 'Class' && parameters.length == 1

--- a/spec/type_converter_spec.rb
+++ b/spec/type_converter_spec.rb
@@ -72,6 +72,8 @@ describe Sord::TypeConverter do
           Types::Nilable.new(Types::Union.new(['String', 'Integer']))
         expect(yard_to_parlour_default(['String', 'nil'])).to eq \
           Types::Nilable.new('String')
+        expect(yard_to_parlour_default('Array<String, nil>')).to eq \
+          Types::Array.new(Types::Nilable.new('String'))
       end
     end
 


### PR DESCRIPTION
Parse `Array<T, nil>` into `Type::Array.new(Types::Nilable.new('String')` instead of the invalid `Types::Array.new(Types::Union.new(['String', 'nil']))`
