### PR TITLE
Update the resolver test to use a bundled gem instead

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in sord.gemspec
 gemspec
+
+# Not in gemspec so it doesn't get distributed or depended on by the built gem.
+# Used by resolver tests, to ensure Sord can import bundled RBIs from gems.
+gem 'resolver-test', path: 'spec/resolver-test-gem'

--- a/spec/resolver-test-gem/rbi/resolver-test.rbi
+++ b/spec/resolver-test-gem/rbi/resolver-test.rbi
@@ -1,0 +1,6 @@
+# typed: true
+
+module ResolverTest
+  class TestClass
+  end
+end

--- a/spec/resolver-test-gem/resolver-test.gemspec
+++ b/spec/resolver-test-gem/resolver-test.gemspec
@@ -1,0 +1,7 @@
+Gem::Specification.new do |spec|
+  spec.name          = "resolver-test"
+  spec.version       = "1.0.0"
+  spec.authors       = ["Aaron Christiansen"]
+  spec.email         = ["aaronc20000@gmail.com"]
+  spec.summary       = "Example gem with an RBI, to test Sord's resolver"
+end

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -163,6 +163,6 @@ describe Sord::Resolver do
 
   it 'resolves included gem rbi files' do
     subject.prepare
-    expect(subject.path_for('Parlour::TypeLoader')).to eq 'Parlour::TypeLoader'
+    expect(subject.path_for('ResolverTest::TestClass')).to eq 'ResolverTest::TestClass'
   end
 end


### PR DESCRIPTION
Sord tries to import RBIs from any gems it can see, while performing its namespace resolution.

Sord's test for this functionality relied on Parlour's bundled RBI.
But Parlour no longer bundles an RBI.

Now, Sord's test suite includes a dummy gem, and the test uses that instead.