### PR TITLE
Don't crash Sord if a constant value doesn't parse

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -19,4 +19,4 @@ jobs:
     - name: Run examples (RBI)
       run: bundle exec rake examples:seed[rbi]
     - name: Run examples (RBS)
-      run: bundle exec rake examples:seed[rbs]
+      run: bundle exec rake examples:reseed[rbs]


### PR DESCRIPTION
#177 parses constant values to resolve heredocs.

In rare cases, constant values might not parse. There are two occurrences of this in Sord's "examples" (in `rake examples`):

1. A non-UTF-8 string in `discordrb`. While Ruby can parse these, the `parser` gem [rejects them intentionally](https://github.com/whitequark/parser/issues/283).

![CleanShot 2025-03-05 at 00 04 46@2x](https://github.com/user-attachments/assets/4561378c-eaff-491b-9394-cee6ed9ec0fd)

2. A possible YARD bug for the docs for `yard` itself. This constant's value doesn't seem to get plucked out correctly:

![CleanShot 2025-03-04 at 23 26 11@2x](https://github.com/user-attachments/assets/293c3aca-6b0c-47b3-b5ae-879922b002eb)

Sord still emits the constant, but also gives a warning just in case it's something that needs the user's attention. 