### PR TITLE
Allow newer RBS gem versions

### DIFF
--- a/sord.gemspec
+++ b/sord.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'commander', '~> 5.0'
   spec.add_dependency "parser"
   spec.add_dependency 'parlour', '~> 9.1'
-  spec.add_dependency 'rbs', '~> 3.0'
+  spec.add_dependency 'rbs', '>=3.0', '<5'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
This allow users to upgrade to recent Tapioca versions.

It now requires newish versions of the spoom gem, which depends on 4.x
pre-releases of the rbs gem.